### PR TITLE
Add dist verification to prevent raw TSX deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Der Build-Prozess wird durch `vite.config.ts` gesteuert.
 - **CI/CD**: Das Repository enthält Konfigurationsdateien für Cloudflare Pages (`cloudflare-pages.json`) und Netlify (`netlify.toml`), die automatische Deployments bei Pushes auf den `main`-Branch ermöglichen. Sicherheitsheader aus `public/_headers` werden dabei automatisch übernommen.
 - **GitHub Pages (Production)**: Stelle unter `Settings → Pages → Build and deployment` sicher, dass die **Source auf “GitHub Actions”** steht. Der Workflow `.github/workflows/pages.yml` baut ausschließlich `dist/`, kopiert `CNAME` sowie den SPA-Fallback (`dist/404.html`) und veröffentlicht dann via `actions/deploy-pages`. Ein regulärer Push auf `main` oder ein manueller `workflow_dispatch` triggert den Deploy.
 - **Dist Smoke-Test**: Vor jedem Deployment `npm run build` lokal ausführen und `dist/index.html` per `npx serve dist` öffnen. Die HTML darf keine direkten `src/*.tsx`-Referenzen mehr enthalten – nur hashed Bundles aus `assets/`.
+- **Dist-Verifikation**: `npm run verify:dist` prüft nach dem Build automatisch, ob `dist/index.html` korrekt auf gebundelte Dateien unter `assets/js` verweist und keine TypeScript-Quellen (`*.tsx`) mehr ausliefert.
 - **Build-Info-Generierung**: Vor jedem Build wird ein Skript ausgeführt, das Build-Informationen (Build-ID, Zeitstempel, Git-SHA) generiert und in der App verfügbar macht.
 
 ## 🤝 Contributing

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
     "release:prepare": "npm run verify && npm run changeset:version",
     "verify": "npm run typecheck && npm run lint && npm run test:unit",
     "clean": "rm -rf dist .vite .cache .tmp coverage test-results",
-    "postbuild": "cp public/_headers dist/_headers && node scripts/generate-routes.js",
+    "postbuild": "cp public/_headers dist/_headers && node scripts/generate-routes.js && node scripts/verify-dist.mjs",
     "prepare": "node -e \"if (process.env.NODE_ENV !== 'production') process.exit(1)\" || husky install",
     "lh": "lhci autorun --config=./lighthouserc.cjs",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "verify:dist": "node scripts/verify-dist.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+
+const DIST_DIR = join(process.cwd(), "dist");
+const INDEX_HTML = join(DIST_DIR, "index.html");
+
+async function ensureFile(path, description) {
+  try {
+    await access(path, constants.R_OK);
+  } catch {
+    throw new Error(`🚫 ${description} fehlt: ${path}`);
+  }
+}
+
+async function main() {
+  await ensureFile(DIST_DIR, "dist-Verzeichnis");
+  await ensureFile(INDEX_HTML, "dist/index.html");
+
+  const indexHtml = await readFile(INDEX_HTML, "utf-8");
+
+  if (/\/src\/main\.tsx/.test(indexHtml)) {
+    throw new Error(
+      "🚫 dist/index.html verweist noch auf /src/main.tsx. Der Produktions-Build wurde nicht gebundled. Bitte `npm run build` ausführen und den dist-Ordner deployen."
+    );
+  }
+
+  const scriptMatches = [...indexHtml.matchAll(/<script[^>]+src=\"([^\"]+)\"/g)]
+    .map(([, src]) => src)
+    .filter((src) => src.endsWith(".js"));
+
+  if (scriptMatches.length === 0) {
+    throw new Error(
+      "🚫 Keine JS-Bundles in dist/index.html gefunden. Erwartet werden Dateien unter /assets/js/*."
+    );
+  }
+
+  const assetScripts = scriptMatches.filter((src) => src.startsWith("/assets/js/"));
+  if (assetScripts.length === 0) {
+    throw new Error(
+      "🚫 dist/index.html enthält keine Hashed-Bundles unter /assets/js/. Bitte sicherstellen, dass Vite den Build erzeugt hat."
+    );
+  }
+
+  await Promise.all(
+    assetScripts.map(async (src) => {
+      const path = join(DIST_DIR, src.replace(/^[\/]/, ""));
+      await ensureFile(path, "JavaScript-Bundle");
+    })
+  );
+
+  if (/\.tsx\b/.test(indexHtml)) {
+    throw new Error(
+      "🚫 dist/index.html enthält noch .tsx-Referenzen. Der Build muss transpilierte JavaScript-Dateien ausliefern."
+    );
+  }
+
+  console.log("✅ dist-Ordner geprüft: index.html liefert gebundelte Assets aus.");
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a postbuild verification script that fails when dist/index.html still references TypeScript sources
- expose the verifier via npm run verify:dist and document the new deployment safeguard in the README

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b45f64348320a4530871da2d3947)