### PR TITLE
Document environment variables and enforce build validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Core runtime configuration
+VITE_OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+VITE_ENV=development
+VITE_ENABLE_ANALYTICS=false
+VITE_ENABLE_PWA=true
+
+# Optional Sentry setup
+# VITE_SENTRY_DSN=
+# SENTRY_ORG=
+# SENTRY_PROJECT=
+# SENTRY_AUTH_TOKEN=
+
+# Local preview overrides
+# VITE_PREVIEW_BASE=
+# VITE_PREVIEW_HOST=127.0.0.1
+# VITE_PREVIEW_PORT=4173

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Der Build-Prozess wird durch `vite.config.ts` gesteuert.
 - **Dist Smoke-Test**: Vor jedem Deployment `npm run build` lokal ausführen und `dist/index.html` per `npx serve dist` öffnen. Die HTML darf keine direkten `src/*.tsx`-Referenzen mehr enthalten – nur hashed Bundles aus `assets/`.
 - **Dist-Verifikation**: `npm run verify:dist` prüft nach dem Build automatisch, ob `dist/index.html` korrekt auf gebundelte Dateien unter `assets/js` verweist und keine TypeScript-Quellen (`*.tsx`) mehr ausliefert.
 - **Build-Info-Generierung**: Vor jedem Build wird ein Skript ausgeführt, das Build-Informationen (Build-ID, Zeitstempel, Git-SHA) generiert und in der App verfügbar macht.
+- **Environment Variables**: Dokumentation aller benötigten Variablen inklusive Deployment-Defaults befindet sich in [docs/environment-variables.md](docs/environment-variables.md).
 
 ## 🤝 Contributing
 

--- a/deploy/cloudflare/cloudflare-pages.json
+++ b/deploy/cloudflare/cloudflare-pages.json
@@ -6,7 +6,11 @@
     "root_dir": ".",
     "environment_variables": {
       "NODE_VERSION": "20.19",
-      "CF_PAGES": "true"
+      "CF_PAGES": "true",
+      "VITE_OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+      "VITE_ENV": "production",
+      "VITE_ENABLE_ANALYTICS": "false",
+      "VITE_ENABLE_PWA": "true"
     }
   },
   "preview": {

--- a/deploy/netlify/netlify.toml
+++ b/deploy/netlify/netlify.toml
@@ -5,6 +5,10 @@
 [build.environment]
   NODE_VERSION = "20"
   NPM_VERSION = "10"
+  VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+  VITE_ENV = "production"
+  VITE_ENABLE_ANALYTICS = "false"
+  VITE_ENABLE_PWA = "true"
 
 # SPA routing - redirect all requests to index.html
 [[redirects]]

--- a/deploy/workers/wrangler.toml
+++ b/deploy/workers/wrangler.toml
@@ -7,11 +7,11 @@ pages_build_output_dir = "dist"
 
 [env.production]
   # Main branch als Produktionsumgebung
-  vars = { NODE_ENV = "production" }
+  vars = { NODE_ENV = "production", VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1", VITE_ENV = "production", VITE_ENABLE_ANALYTICS = "false", VITE_ENABLE_PWA = "true" }
 
 [env.preview]
   # Alle anderen Branches als Preview
-  vars = { NODE_ENV = "development" }
+  vars = { NODE_ENV = "development", VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1", VITE_ENV = "staging", VITE_ENABLE_ANALYTICS = "false", VITE_ENABLE_PWA = "true" }
 
 # Note: Build configuration is handled by Cloudflare Pages dashboard
 # Cache purging and deploy hooks are managed through Pages dashboard

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,56 @@
+# Environment Variables
+
+This project relies on a small set of environment variables for build-time validation, runtime configuration, and optional tooling. Frontend values are exposed via the `VITE_` prefix so they can be consumed safely through Vite’s runtime environment. The `scripts/validate-env.mjs` check runs before each production build and fails if required variables are missing, so make sure your CI/CD pipelines export the values listed below. 【F:scripts/validate-env.mjs†L1-L56】
+
+A starter `.env.example` is included for local development—copy it to `.env.local` (ignored by Git) and adjust the values for your environment. 【F:.env.example†L1-L16】
+
+## Core runtime variables (must be provided)
+
+- `VITE_OPENROUTER_BASE_URL` – Base URL for all OpenRouter API calls. Defaults to `https://openrouter.ai/api/v1`, but must be explicitly configured in production to pass validation. 【F:src/config/env.ts†L5-L33】【F:scripts/validate-env.mjs†L15-L38】
+- `VITE_ENV` – Human-readable deployment label used by error tracking and release tagging (`production`, `staging`, etc.). Also enforced by the validation script. 【F:scripts/validate-env.mjs†L15-L38】【F:src/lib/monitoring/sentry.tsx†L20-L40】
+
+## Automatically generated during the build
+
+These values are produced by `scripts/build-info.js` and injected before every build; you should not set them manually.
+
+- `VITE_BUILD_ID`, `VITE_BUILD_TIME`, `VITE_BUILD_TIMESTAMP`, `VITE_GIT_SHA`, `VITE_GIT_BRANCH`, `VITE_VERSION` – Release metadata written to `.env.build` and bundled artifacts. 【F:scripts/build-info.js†L41-L99】
+- `VITE_BUILD_TIMESTAMP` is also embedded in the service-worker cache token to force updates between deploys. 【F:src/lib/pwa/registerSW.ts†L3-L11】
+
+## Optional frontend toggles
+
+- `VITE_ENABLE_ANALYTICS` – Enables or disables analytics collection (string boolean). 【F:src/config/env.ts†L13-L18】
+- `VITE_ENABLE_DEBUG` – Turns on verbose environment logging in development builds. 【F:src/config/env.ts†L34-L39】
+- `VITE_ENABLE_PWA` – Controls whether PWA features are active; defaults to `true`. 【F:src/config/env.ts†L41-L45】
+- `VITE_BASE_URL` – Overrides the deployment base path used when Vite builds the SPA. 【F:src/config/env.ts†L31-L33】【F:vite.config.ts†L62-L78】
+- `VITE_PORT` – Custom port for the Vite dev server when running `npm run dev`. 【F:vite.config.ts†L191-L194】
+- `VITE_UI_V2_PERCENTAGE`, `VITE_FORCE_UI_VERSION` – Reserved knobs for future UI rollout logic; kept in the typed env definition for compatibility. 【F:vite-env.d.ts†L3-L25】
+- Feature-flag overrides follow the pattern `VITE_FF_<FLAGNAME>` (e.g. `VITE_FF_NEW_DRAWER=true`) and map directly to keys defined in `src/config/flags.ts`. 【F:src/config/flags.ts†L41-L74】
+
+## Observability & release management
+
+- `VITE_SENTRY_DSN` – Client-side DSN required to bootstrap Sentry in production. 【F:src/lib/monitoring/sentry.tsx†L20-L38】
+- `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` – Build-time credentials that allow the Sentry Vite plugin to upload source maps when `VITE_SENTRY_DSN` is set. 【F:vite.config.ts†L84-L105】【F:src/lib/monitoring/README.md†L7-L20】
+
+## Preview & deployment helpers
+
+- `CF_PAGES`, `CF_PAGES_URL` – Automatically set on Cloudflare Pages; used to detect the correct base URL when running `npm run preview`. 【F:scripts/run-preview.mjs†L13-L21】
+- `GITHUB_ACTIONS`, `GITHUB_REPOSITORY` – Allow the preview server to infer a GitHub Pages-style base path during CI previews. 【F:scripts/run-preview.mjs†L15-L21】
+- `VITE_PREVIEW_BASE`, `VITE_PREVIEW_HOST`, `VITE_PREVIEW_PORT` – Override the preview server’s base path, host, or port. 【F:scripts/run-preview.mjs†L13-L30】
+- `DEBUG_PREVIEW` – When set to `1`, logs detailed preview-server output for troubleshooting. 【F:scripts/run-preview.mjs†L70-L92】
+- `BUNDLE_ANALYZE`, `BUNDLE_ANALYZE_MODE` – Control the optional bundle analyzer plug-in invoked through `npm run analyze`. 【F:vite.config.ts†L8-L12】
+- `DEBUG_SOURCEMAP` – Enables source-map generation for the `npm run build:debug` workflow. 【F:package.json†L6-L38】
+
+## Testing & QA
+
+- `PLAYWRIGHT_PORT`, `PLAYWRIGHT_BASE_URL`, `CI` – Configure the Playwright test server and adjust retries/timeouts in CI environments. 【F:playwright.config.ts†L3-L12】
+- `LHCI_HOST`, `LHCI_PORT`, `LHCI_SKIP_SERVER` – Supply host/port overrides and control whether Lighthouse CI should boot the preview server. 【F:lighthouserc.cjs†L6-L28】
+
+## Deployment defaults
+
+The repository ships with provider configs that set safe defaults for the required runtime variables. Adjust them to reference your secret manager in production.
+
+- Cloudflare Pages: `deploy/cloudflare/cloudflare-pages.json` seeds `VITE_OPENROUTER_BASE_URL`, `VITE_ENV`, analytics, and PWA toggles. 【F:deploy/cloudflare/cloudflare-pages.json†L3-L19】
+- Netlify: `deploy/netlify/netlify.toml` exports the same runtime values for Netlify builds. 【F:deploy/netlify/netlify.toml†L1-L12】
+- Cloudflare Workers/Pages environments: `deploy/workers/wrangler.toml` assigns production and preview defaults for the Vite runtime flags. 【F:deploy/workers/wrangler.toml†L8-L17】
+
+With these values in place, the validation script will succeed and the application will receive consistent configuration in every environment. 【F:scripts/validate-env.mjs†L15-L56】

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "generate-tokens": "node scripts/generate-tokens.mjs",
-    "prebuild": "node scripts/build-info.js && npm run generate-tokens",
+    "prebuild": "node scripts/validate-env.mjs && node scripts/build-info.js && npm run generate-tokens",
     "build": "vite build",
     "build:debug": "DEBUG_SOURCEMAP=1 vite build --mode development",
     "preview": "node ./scripts/run-preview.mjs",

--- a/scripts/validate-env.mjs
+++ b/scripts/validate-env.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { loadEnv } from "vite";
+import { resolve } from "node:path";
+
+if (process.env.SKIP_ENV_VALIDATION === "1") {
+  process.exit(0);
+}
+
+const mode = process.env.BUILD_MODE || process.env.NODE_ENV || "production";
+const root = resolve(process.cwd());
+
+const fileEnv = loadEnv(mode, root, "");
+const env = { ...fileEnv, ...process.env };
+
+const requiredFrontend = [
+  {
+    key: "VITE_OPENROUTER_BASE_URL",
+    description: "Base URL for the OpenRouter API",
+  },
+  {
+    key: "VITE_ENV",
+    description: "Deployment environment label (production, staging, etc.)",
+  },
+];
+
+const missing = requiredFrontend.filter((item) => {
+  const value = env[item.key];
+  return typeof value !== "string" || value.trim() === "";
+});
+
+if (missing.length > 0) {
+  console.error("\n❌ Missing required environment variables for the build:");
+  for (const item of missing) {
+    console.error(`  - ${item.key}: ${item.description}`);
+  }
+  console.error("\nSet the variables in your deployment environment or a .env file.");
+  console.error("You can bypass this check temporarily with SKIP_ENV_VALIDATION=1, but this is not recommended.");
+  process.exit(1);
+}
+
+const sentryConfig = ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"];
+const hasSentryDsn = typeof env.VITE_SENTRY_DSN === "string" && env.VITE_SENTRY_DSN.trim() !== "";
+const missingSentry = sentryConfig.filter((key) => {
+  const value = env[key];
+  return typeof value !== "string" || value.trim() === "";
+});
+
+if (hasSentryDsn && missingSentry.length > 0) {
+  console.warn("\n⚠️ Sentry DSN is configured but some build-time credentials are missing:");
+  for (const key of missingSentry) {
+    console.warn(`  - ${key}`);
+  }
+  console.warn("Sentry source map upload will be skipped until all credentials are provided.\n");
+}
+
+console.log("✅ Environment validation passed.");


### PR DESCRIPTION
## Summary
- add a comprehensive environment variable reference and sample .env file
- validate required Vite runtime variables before building and wire defaults into deployment configs
- reference the new documentation from the README

## Testing
- VITE_OPENROUTER_BASE_URL=https://openrouter.ai/api/v1 VITE_ENV=development node scripts/validate-env.mjs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ef0a21b88320a2ba1a21badf0da4)