### PR TITLE
Document environment variables and configure deployment defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Die Anwendung ist hochgradig konfigurierbar, um Flexibilität und einfache Wartu
   - **Validierung mit Zod**: Ein `zod`-Schema definiert, welche Variablen erwartet werden, welchen Typ sie haben und was ihre Standardwerte sind.
   - **Typensicherheit**: Nach der Validierung steht ein stark typisiertes `EnvConfig`-Objekt zur Verfügung.
   - **Beispiele**: `VITE_OPENROUTER_BASE_URL`, `VITE_ENABLE_ANALYTICS` (wird von einem String zu einem Boolean transformiert), `VITE_BUILD_ID`.
+  - **Vollständige Übersicht**: Alle aktuell ausgewerteten Variablen (inkl. Build- und Tooling-Flags) sind in [`docs/ENVIRONMENT_VARIABLES.md`](docs/ENVIRONMENT_VARIABLES.md) dokumentiert.
 
 - **Feature Flags (`src/config/featureFlags.ts`)**
   Ermöglicht das Umschalten von Funktionen zur Laufzeit, ohne einen neuen Build zu benötigen. Die Zustände werden im `localStorage` gespeichert und können von Entwicklern manuell geändert werden.

--- a/deploy/cloudflare/cloudflare-pages.json
+++ b/deploy/cloudflare/cloudflare-pages.json
@@ -6,7 +6,23 @@
     "root_dir": ".",
     "environment_variables": {
       "NODE_VERSION": "20.19",
-      "CF_PAGES": "true"
+      "CF_PAGES": "true",
+      "VITE_OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+      "VITE_BASE_URL": "/",
+      "VITE_ENABLE_ANALYTICS": "false",
+      "VITE_ENABLE_DEBUG": "false",
+      "VITE_ENABLE_PWA": "true",
+      "VITE_ENV": "production",
+      "VITE_SENTRY_DSN": "",
+      "VITE_BUILD_ID": "",
+      "VITE_BUILD_TIME": "",
+      "VITE_BUILD_TIMESTAMP": "",
+      "VITE_GIT_SHA": "",
+      "VITE_GIT_BRANCH": "",
+      "VITE_VERSION": "",
+      "SENTRY_ORG": "disa-ai",
+      "SENTRY_PROJECT": "disa-ai-web",
+      "SENTRY_AUTH_TOKEN": ""
     }
   },
   "preview": {

--- a/deploy/netlify/netlify.toml
+++ b/deploy/netlify/netlify.toml
@@ -5,6 +5,22 @@
 [build.environment]
   NODE_VERSION = "20"
   NPM_VERSION = "10"
+  VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+  VITE_BASE_URL = "/"
+  VITE_ENABLE_ANALYTICS = "false"
+  VITE_ENABLE_DEBUG = "false"
+  VITE_ENABLE_PWA = "true"
+  VITE_ENV = "production"
+  VITE_SENTRY_DSN = ""
+  VITE_BUILD_ID = ""
+  VITE_BUILD_TIME = ""
+  VITE_BUILD_TIMESTAMP = ""
+  VITE_GIT_SHA = ""
+  VITE_GIT_BRANCH = ""
+  VITE_VERSION = ""
+  SENTRY_ORG = "disa-ai"
+  SENTRY_PROJECT = "disa-ai-web"
+  SENTRY_AUTH_TOKEN = ""
 
 # SPA routing - redirect all requests to index.html
 [[redirects]]

--- a/deploy/workers/wrangler.toml
+++ b/deploy/workers/wrangler.toml
@@ -7,11 +7,47 @@ pages_build_output_dir = "dist"
 
 [env.production]
   # Main branch als Produktionsumgebung
-  vars = { NODE_ENV = "production" }
+  vars = {
+    NODE_ENV = "production",
+    VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1",
+    VITE_BASE_URL = "/",
+    VITE_ENABLE_ANALYTICS = "false",
+    VITE_ENABLE_DEBUG = "false",
+    VITE_ENABLE_PWA = "true",
+    VITE_ENV = "production",
+    VITE_SENTRY_DSN = "",
+    VITE_BUILD_ID = "",
+    VITE_BUILD_TIME = "",
+    VITE_BUILD_TIMESTAMP = "",
+    VITE_GIT_SHA = "",
+    VITE_GIT_BRANCH = "",
+    VITE_VERSION = "",
+    SENTRY_ORG = "disa-ai",
+    SENTRY_PROJECT = "disa-ai-web",
+    SENTRY_AUTH_TOKEN = ""
+  }
 
 [env.preview]
   # Alle anderen Branches als Preview
-  vars = { NODE_ENV = "development" }
+  vars = {
+    NODE_ENV = "development",
+    VITE_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1",
+    VITE_BASE_URL = "/",
+    VITE_ENABLE_ANALYTICS = "false",
+    VITE_ENABLE_DEBUG = "false",
+    VITE_ENABLE_PWA = "true",
+    VITE_ENV = "staging",
+    VITE_SENTRY_DSN = "",
+    VITE_BUILD_ID = "",
+    VITE_BUILD_TIME = "",
+    VITE_BUILD_TIMESTAMP = "",
+    VITE_GIT_SHA = "",
+    VITE_GIT_BRANCH = "",
+    VITE_VERSION = "",
+    SENTRY_ORG = "disa-ai",
+    SENTRY_PROJECT = "disa-ai-web",
+    SENTRY_AUTH_TOKEN = ""
+  }
 
 # Note: Build configuration is handled by Cloudflare Pages dashboard
 # Cache purging and deploy hooks are managed through Pages dashboard

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,56 @@
+# Environment Variables
+
+Diese Referenz listet alle Umgebungsvariablen auf, die das Projekt aktuell auswertet. Alle Variablen, die im Browser zur Verfügung stehen müssen, tragen bereits ein `VITE_`-Präfix (Vite-spezifisch) und können gefahrlos exponiert werden. Build- und Tooling-Variablen ohne `VITE_`-Präfix bleiben ausschließlich im Node-Kontext.
+
+> 💡 **Hinweis:** Die Variablen `VITE_BUILD_*`, `VITE_GIT_*` und `VITE_VERSION` werden während `npm run build` automatisch über `scripts/build-info.js` generiert und müssen nicht manuell gepflegt werden.
+
+## Runtime (Client, `import.meta.env`)
+
+| Variable | Pflicht? | Default / Verhalten | Zweck | Referenz |
+| --- | --- | --- | --- | --- |
+| `VITE_OPENROUTER_BASE_URL` | nein | `https://openrouter.ai/api/v1` | Basis-URL für alle OpenRouter-Anfragen. | [`src/services/openrouter.ts`](../src/services/openrouter.ts) |
+| `VITE_ENABLE_ANALYTICS` | nein | `false` | Aktiviert optionales Analytics-Tracking. | [`src/config/env.ts`](../src/config/env.ts) |
+| `VITE_ENABLE_DEBUG` | nein | `false` | Schaltet zusätzliche Diagnose-Logs frei. | [`src/config/env.ts`](../src/config/env.ts) |
+| `VITE_ENABLE_PWA` | nein | `true` | Kann PWA-Features deaktivieren (Fallback-Modus). | [`src/config/env.ts`](../src/config/env.ts) |
+| `VITE_BASE_URL` | nein | `/` | Basis-Pfad der Anwendung, wird im Build validiert. | [`vite.config.ts`](../vite.config.ts) |
+| `VITE_SENTRY_DSN` | optional | – | Aktiviert den Sentry-Client im Browser. | [`src/lib/monitoring/sentry.tsx`](../src/lib/monitoring/sentry.tsx) |
+| `VITE_ENV` | optional | `production` | Environment-Label für Monitoring & Logging. | [`src/lib/monitoring/sentry.tsx`](../src/lib/monitoring/sentry.tsx) |
+| `VITE_BUILD_ID` | automatisch | generiert | Build-Kennung für Release-Tracking. | [`scripts/build-info.js`](../scripts/build-info.js) |
+| `VITE_BUILD_TIME` | automatisch | generiert | ISO-Zeitstempel des Builds. | [`scripts/build-info.js`](../scripts/build-info.js) |
+| `VITE_BUILD_TIMESTAMP` | automatisch | generiert | Numerischer Zeitstempel (Cache-Busting). | [`src/lib/pwa/registerSW.ts`](../src/lib/pwa/registerSW.ts) |
+| `VITE_GIT_SHA` | automatisch | generiert | Git SHA für Debugging. | [`src/components/BuildInfo.tsx`](../src/components/BuildInfo.tsx) |
+| `VITE_GIT_BRANCH` | automatisch | generiert | Git Branch für Debugging. | [`src/components/BuildInfo.tsx`](../src/components/BuildInfo.tsx) |
+| `VITE_VERSION` | automatisch | generiert | Semantische Versionsnummer. | [`src/components/BuildInfo.tsx`](../src/components/BuildInfo.tsx) |
+| `VITE_PORT` | nein | `5173` | Dev-Server-Port (Vite). | [`vite.config.ts`](../vite.config.ts) |
+| `VITE_PREVIEW_BASE` | optional | `/` | Überschreibt die Basis-URL für `npm run preview`. | [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `VITE_PREVIEW_HOST` | optional | `0.0.0.0` | Hostname für `npm run preview`. | [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `VITE_PREVIEW_PORT` | optional | `4173` | Port für `npm run preview`. | [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `VITE_FF_*` | optional | – | Laufzeit-Feature-Flags (per Präfix `VITE_FF_`). | [`src/config/flags.ts`](../src/config/flags.ts) |
+
+## Build-, Monitoring- & Tooling-Variablen (Node-Kontext)
+
+| Variable | Pflicht? | Zweck | Referenz |
+| --- | --- | --- | --- |
+| `NODE_ENV` | ja (Build) | Steuert Build-/Runtime-Modus. | Diverse, z.B. [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `BUNDLE_ANALYZE` | optional | Aktiviert Bundle-Analyser. | [`vite.config.ts`](../vite.config.ts) |
+| `BUNDLE_ANALYZE_MODE` | optional | Modus für Bundle-Analyser (`static`, `server`, …). | [`vite.config.ts`](../vite.config.ts) |
+| `DEBUG_SOURCEMAP` | optional | Aktiviert Sourcemaps im Debug-Build. | [`package.json`](../package.json) |
+| `SENTRY_AUTH_TOKEN` | optional | Authentifizierung für Sentry Source Maps. | [`vite.config.ts`](../vite.config.ts) |
+| `SENTRY_ORG` | optional | Sentry-Organisation (Build-Zeit). | [`vite.config.ts`](../vite.config.ts) |
+| `SENTRY_PROJECT` | optional | Sentry-Projektname (Build-Zeit). | [`vite.config.ts`](../vite.config.ts) |
+| `CF_PAGES` / `CF_PAGES_URL` | automatisch | Erkennung für Cloudflare Pages Deployments. | [`vite.config.ts`](../vite.config.ts) |
+| `GITHUB_ACTIONS`, `GITHUB_REPOSITORY` | automatisch | Metadaten für Preview-Base-Berechnung. | [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `DEBUG_PREVIEW` | optional | Zusätzliche Logs im Preview-Skript. | [`scripts/run-preview.mjs`](../scripts/run-preview.mjs) |
+| `LHCI_HOST`, `LHCI_PORT`, `LHCI_SKIP_SERVER` | optional | Steuerung für Lighthouse CI. | [`lighthouserc.cjs`](../lighthouserc.cjs) |
+| `PLAYWRIGHT_BASE_URL`, `PLAYWRIGHT_PORT`, `PLAYWRIGHT_WEB_SERVER`, `PLAYWRIGHT_WEB_PORT` | optional | Playwright Test-Setup (lokaler Server). | [`playwright.config.ts`](../playwright.config.ts), [`scripts/setup_disaai.sh`](../scripts/setup_disaai.sh) |
+| `CI` | automatisch | Anpassung von Timeouts/Worker-Anzahl in CI. | [`playwright.config.ts`](../playwright.config.ts) |
+
+## Deployment Default Values
+
+Die Deployments setzen sichere Standardwerte, die bei Bedarf über Plattform-Secrets überschrieben werden können:
+
+- **Netlify**: siehe [`deploy/netlify/netlify.toml`](../deploy/netlify/netlify.toml)
+- **Cloudflare Pages**: siehe [`deploy/cloudflare/cloudflare-pages.json`](../deploy/cloudflare/cloudflare-pages.json)
+- **Cloudflare Workers Preview**: siehe [`deploy/workers/wrangler.toml`](../deploy/workers/wrangler.toml)
+
+Sensitive Werte wie `VITE_SENTRY_DSN` oder `SENTRY_AUTH_TOKEN` sind absichtlich leer vorbelegt und müssen in den jeweiligen Deployment-Dashboards als Secret hinterlegt werden.


### PR DESCRIPTION
## Summary
- add a dedicated environment variable reference and link it from the README
- seed Netlify, Cloudflare Pages, and Wrangler configs with default Vite and Sentry variables
- ensure all runtime and tooling env vars are documented for deployment

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911eefcbd2083208f6f7b1e9bd671cd)