### PR TITLE
Add Cloudflare Pages API functions for chat proxy and feedback storage

### DIFF
--- a/deploy/cloudflare/cloudflare-pages.json
+++ b/deploy/cloudflare/cloudflare-pages.json
@@ -1,7 +1,7 @@
 {
   "name": "disaai",
   "build": {
-    "command": "npm run build",
+    "command": "npm ci && npm run build",
     "destination": "dist",
     "root_dir": ".",
     "environment_variables": {

--- a/functions/api/chat.ts
+++ b/functions/api/chat.ts
@@ -1,0 +1,126 @@
+import type { PagesFunction } from "@cloudflare/workers-types";
+
+const ALLOWED_ORIGIN = "https://disaai.de";
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 20;
+const rateLimitState = new Map<string, number[]>();
+
+interface Env {
+  OPENROUTER_API_KEY: string;
+}
+
+const createCorsHeaders = (origin: string | null) => {
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  headers.set("Access-Control-Allow-Headers", "content-type, accept");
+  headers.set("Access-Control-Max-Age", "86400");
+  if (origin === ALLOWED_ORIGIN) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Vary", "Origin");
+  }
+  return headers;
+};
+
+const getClientIdentifier = (request: Request) =>
+  request.headers.get("cf-connecting-ip") ?? request.headers.get("x-forwarded-for") ?? "anonymous";
+
+const isRateLimited = (clientId: string) => {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const requestTimes = rateLimitState.get(clientId) ?? [];
+  const filteredTimes = requestTimes.filter((timestamp) => timestamp > windowStart);
+
+  if (filteredTimes.length >= RATE_LIMIT_MAX_REQUESTS) {
+    rateLimitState.set(clientId, filteredTimes);
+    return true;
+  }
+
+  filteredTimes.push(now);
+  if (filteredTimes.length > RATE_LIMIT_MAX_REQUESTS) {
+    filteredTimes.splice(0, filteredTimes.length - RATE_LIMIT_MAX_REQUESTS);
+  }
+  rateLimitState.set(clientId, filteredTimes);
+  return false;
+};
+
+export const onRequestOptions: PagesFunction = async ({ request }) => {
+  const corsHeaders = createCorsHeaders(request.headers.get("Origin"));
+  return new Response(null, { status: 204, headers: corsHeaders });
+};
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const origin = request.headers.get("Origin");
+  const corsHeaders = createCorsHeaders(origin);
+
+  if (!env.OPENROUTER_API_KEY) {
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Missing server configuration." }), {
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+
+  const clientId = getClientIdentifier(request);
+  if (isRateLimited(clientId)) {
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Too many requests. Please slow down." }), {
+      status: 429,
+      headers: corsHeaders,
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Invalid JSON payload." }), {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+
+  let upstreamResponse: Response;
+  try {
+    const acceptHeader = request.headers.get("Accept");
+    const upstreamHeaders: Record<string, string> = {
+      Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": "https://disaai.de",
+      "X-Title": "DisaAI",
+    };
+    if (acceptHeader) {
+      upstreamHeaders["Accept"] = acceptHeader;
+    }
+
+    upstreamResponse = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: upstreamHeaders,
+    });
+  } catch (error) {
+    console.error("Failed to reach OpenRouter", error);
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Unable to reach the chat service." }), {
+      status: 502,
+      headers: corsHeaders,
+    });
+  }
+
+  const responseHeaders = new Headers(corsHeaders);
+  responseHeaders.set("Cache-Control", "no-store");
+  responseHeaders.set(
+    "Content-Type",
+    upstreamResponse.headers.get("content-type") ?? "application/json",
+  );
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers: responseHeaders,
+  });
+};

--- a/functions/api/feedback.ts
+++ b/functions/api/feedback.ts
@@ -1,0 +1,99 @@
+import type { PagesFunction } from "@cloudflare/workers-types";
+
+const ALLOWED_ORIGIN = "https://disaai.de";
+
+interface Env {
+  feedback: KVNamespace;
+}
+
+interface FeedbackPayload {
+  message: string;
+  email?: string;
+  metadata?: unknown;
+}
+
+const createCorsHeaders = (origin: string | null) => {
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  headers.set("Access-Control-Allow-Headers", "content-type, accept");
+  headers.set("Access-Control-Max-Age", "86400");
+  if (origin === ALLOWED_ORIGIN) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Vary", "Origin");
+  }
+  return headers;
+};
+
+const validatePayload = (data: unknown): data is FeedbackPayload => {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const { message, email } = data as FeedbackPayload;
+  if (typeof message !== "string" || message.trim().length === 0) {
+    return false;
+  }
+
+  if (email !== undefined && typeof email !== "string") {
+    return false;
+  }
+
+  return true;
+};
+
+export const onRequestOptions: PagesFunction = async ({ request }) => {
+  const corsHeaders = createCorsHeaders(request.headers.get("Origin"));
+  return new Response(null, { status: 204, headers: corsHeaders });
+};
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const origin = request.headers.get("Origin");
+  const corsHeaders = createCorsHeaders(origin);
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Invalid JSON payload." }), {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+
+  if (!validatePayload(payload)) {
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Invalid feedback payload." }), {
+      status: 422,
+      headers: corsHeaders,
+    });
+  }
+
+  const feedbackPayload = payload as FeedbackPayload;
+  const feedbackId = `${Date.now()}-${crypto.randomUUID()}`;
+  const storedRecord = {
+    ...feedbackPayload,
+    createdAt: new Date().toISOString(),
+  };
+
+  try {
+    await env.feedback.put(feedbackId, JSON.stringify(storedRecord));
+  } catch (error) {
+    console.error("Failed to store feedback", error);
+    corsHeaders.set("Content-Type", "application/json");
+    corsHeaders.set("Cache-Control", "no-store");
+    return new Response(JSON.stringify({ error: "Unable to save feedback." }), {
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+
+  corsHeaders.set("Content-Type", "application/json");
+  corsHeaders.set("Cache-Control", "no-store");
+  return new Response(JSON.stringify({ success: true }), {
+    status: 201,
+    headers: corsHeaders,
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@axe-core/playwright": "^4.10.2",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.29.7",
+        "@cloudflare/workers-types": "^4.20251111.0",
         "@eslint/js": "^9.36.0",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.56.0",
@@ -2178,6 +2179,13 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20251111.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251111.0.tgz",
+      "integrity": "sha512-C8BgQRJlnxcUGycNr8pSKs7WBDQwc43p3pnuGv+Lc0KR2y6raR/9Rs7/lPqQ086ECYSiNqU6IPcbeszKbg4LXA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@axe-core/playwright": "^4.10.2",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.29.7",
+    "@cloudflare/workers-types": "^4.20251111.0",
     "@eslint/js": "^9.36.0",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.56.0",


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages function that proxies `/api/chat` requests to OpenRouter with streaming support, rate limiting, and CORS restricted to https://disaai.de
- add a `/api/feedback` function backed by the `feedback` KV namespace to collect submissions with validated payloads
- update the Pages build command to run `npm ci` before building and add Cloudflare worker type definitions for the new functions

## Testing
- npm run lint -- functions/api *(fails: existing lint violations in src/main.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691316bbd8408320b7b6d08c803399e5)