### PR TITLE
Fix misplaced skeleton import in EnhancedModelsInterface

### DIFF
--- a/src/components/models/EnhancedModelsInterface.tsx
+++ b/src/components/models/EnhancedModelsInterface.tsx
@@ -18,6 +18,7 @@ import { Badge, Button, Input } from "../ui";
 import { Card } from "../ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/Dialog";
 import { FilterChip } from "../ui/FilterChip";
+import { Skeleton } from "../ui/skeleton";
 import { useToasts } from "../ui/toast/ToastsProvider";
 import { ModelComparisonTable } from "./ModelComparisonTable";
 
@@ -539,26 +540,20 @@ export function EnhancedModelsInterface({ className }: EnhancedModelsInterfacePr
     setIsCompareOpen(true);
   }, [selectedModels, enhancedModels, push]);
 
-import { Skeleton } from "../ui/skeleton";
-
-// ... (keep existing imports)
-
-// ... (keep existing component logic)
-
   // Show loading state while models are being loaded
   if (isLoadingModels) {
     return (
       <div className={`flex flex-col h-full bg-bg-1 ${className || ""}`}>
         <div className="p-4 space-y-4">
-          <Skeleton className="h-10 w-full rounded-full" /> {/* Search bar skeleton */}
+          <Skeleton className="h-10 w-full rounded-full" />
           <div className="flex gap-2">
-            <Skeleton className="h-9 w-24 rounded-full" /> {/* Filter chip skeleton */}
-            <Skeleton className="h-9 w-24 rounded-full" /> {/* Filter chip skeleton */}
-            <Skeleton className="h-9 w-24 rounded-full" /> {/* Filter chip skeleton */}
+            <Skeleton className="h-9 w-24 rounded-full" />
+            <Skeleton className="h-9 w-24 rounded-full" />
+            <Skeleton className="h-9 w-24 rounded-full" />
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-[180px] w-full" /> // Model card skeleton
+              <Skeleton key={i} className="h-[180px] w-full" />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move the Skeleton import to the top of EnhancedModelsInterface so it is processed correctly during bundling
- clean up the loading skeleton JSX to avoid invalid inline comments inside the map expression

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d68a25048320b7ef89f776305ce9)