### PR TITLE
chore: skip cloudflare deploy when token missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
     name: "Preview Deploy to Cloudflare Pages"
     runs-on: ubuntu-latest
     needs: [build-and-budget]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && secrets.CLOUDFLARE_API_TOKEN != ''
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v5
@@ -225,3 +225,13 @@ jobs:
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
           directory: "dist"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  preview-cloudflare-skip:
+    name: "Skip Cloudflare Pages Preview"
+    runs-on: ubuntu-latest
+    needs: [build-and-budget]
+    if: github.event_name == 'pull_request' && secrets.CLOUDFLARE_API_TOKEN == ''
+    steps:
+      - name: "Cloudflare Preview Skipped"
+        run: |
+          echo "Cloudflare Pages preview deployment skipped because CLOUDFLARE_API_TOKEN is not configured." | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
     name: "Deploy to Cloudflare Pages"
     runs-on: ubuntu-latest
     needs: [release]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && secrets.CLOUDFLARE_API_TOKEN != ''
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v5
@@ -216,3 +216,13 @@ jobs:
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
           directory: "dist"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-cloudflare-skip:
+    name: "Skip Cloudflare Pages Deployment"
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && secrets.CLOUDFLARE_API_TOKEN == ''
+    steps:
+      - name: "Cloudflare Production Deployment Skipped"
+        run: |
+          echo "Cloudflare Pages production deployment skipped because CLOUDFLARE_API_TOKEN is not configured." | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- skip Cloudflare preview and production deployments when the Cloudflare API token secret is not configured
- add explicit workflow summaries noting when deployments are skipped

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e639d4d48320ae08549a4f3406cd)