### PR TITLE
Fix Liquid parsing in UI guidelines code snippets

### DIFF
--- a/docs/UI-Richtlinien.md
+++ b/docs/UI-Richtlinien.md
@@ -362,6 +362,7 @@ xl: 1280px  /* Große Desktops */
 
 ### 5.2 Safe-Area-Insets
 
+{% raw %}
 ```tsx
 // Bottom-Nav
 <nav className="pb-[max(env(safe-area-inset-bottom),0.35rem)]">
@@ -379,9 +380,11 @@ xl: 1280px  /* Große Desktops */
   ...
 </div>
 ```
+{% endraw %}
 
 ### 5.3 Viewport-Handling
 
+{% raw %}
 ```tsx
 // Für iOS Keyboard
 const viewport = useVisualViewport();
@@ -396,6 +399,7 @@ const viewport = useVisualViewport();
   ...
 </div>
 ```
+{% endraw %}
 
 ## 6. Accessibility (A11y)
 


### PR DESCRIPTION
## Summary
- wrap the React code examples containing double braces in the UI guidelines doc with Liquid raw blocks
- prevent Liquid from interpreting the examples so the Jekyll build can complete

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e66d35a08320ac5ab2479e595119)