### PR TITLE
Fix styles entrypoint to load Tailwind layers

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,16 +10,16 @@
  */
 
 /* Import consolidated styles */
-@import "./styles/z-index-system.css"; /* FIRST: Establish z-index hierarchy */
-@import "./styles/design-tokens-consolidated.css"; /* NEW: Aurora Design System Tokens */
-@import "./styles/base.css";
-@import "./styles/components.css";
-@import "./styles/grid-system.css"; /* NEW: Responsive Grid System */
-@import "./styles/white-space.css"; /* NEW: White Space Management System */
-@import "./styles/page-spacing.css"; /* NEW: Page Margins and Spacing System */
-@import "./styles/vertical-rhythm.css"; /* NEW: Vertical Rhythm and Typography System */
-@import "./styles/interactive-states.css"; /* NEW: Interactive States System */
-@import "./styles/ui-state-animations.css"; /* Universal State System animations */
+@import "./styles/z-index-system.css"; /* Establish stacking context FIRST */
+@import "./styles/design-tokens-consolidated.css"; /* Aurora Design System Tokens */
+@import "./styles/base.css"; /* Reset + safe-area handling */
+@import "./styles/components.css"; /* Legacy component shims */
+@import "./styles/grid-system.css"; /* Responsive layout helpers */
+@import "./styles/white-space.css"; /* Space + rhythm primitives */
+@import "./styles/page-spacing.css"; /* Page Margins and Spacing System */
+@import "./styles/vertical-rhythm.css"; /* Typography rhythm */
+@import "./styles/interactive-states.css"; /* Hover/focus system */
+@import "./styles/ui-state-animations.css"; /* State animations */
 
 /* Tailwind CSS */
 @tailwind base;
@@ -33,6 +33,14 @@
 @layer base {
   html {
     color-scheme: dark;
+  }
+
+  body {
+    min-height: 100dvh;
+    background: linear-gradient(180deg, var(--bg-aurora-0), var(--bg-aurora-2));
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
   }
 
   body::after {
@@ -197,8 +205,24 @@
     color: var(--color-brand-primary);
   }
 
+  .surface-card {
+    @apply rounded-[var(--radius-lg)] p-6 flex flex-col gap-4;
+    background: var(--glass-surface-medium);
+    border: 1px solid var(--glass-border-subtle);
+    box-shadow: var(--shadow-premium-medium);
+    backdrop-filter: blur(var(--backdrop-blur-medium));
+    position: relative;
+    isolation: isolate;
+  }
+
   .surface-card--raised {
+    background: var(--glass-surface-strong);
     box-shadow: var(--shadow-premium-strong);
+  }
+
+  .surface-card--frosted {
+    background: var(--glass-surface-overlay);
+    box-shadow: var(--shadow-premium-medium);
   }
 
   /* ========================================================================
@@ -257,5 +281,25 @@
     .brand-panel::before {
       animation: none;
     }
+  }
+}
+
+@layer utilities {
+  .glass-border {
+    border-color: var(--glass-border-aurora);
+  }
+
+  .glass-sheen {
+    position: relative;
+  }
+
+  .glass-sheen::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.25), transparent 45%);
+    opacity: 0.7;
+    pointer-events: none;
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,4 @@
-import "./index.css"; // Consolidated CSS: unified-tokens, base, components, Tailwind
-import "./styles/base.css";
-import "./styles/components.css";
+import "./index.css"; // Consolidated CSS: tokens + Tailwind layers
 import "./lib/css-feature-detection";
 import "./lib/accessibility";
 


### PR DESCRIPTION
## Summary
- ensure the consolidated index.css imports tokens first and defines Tailwind-driven base/components/utilities layers so premium layout/glass tokens load again
- add dedicated surface card and glass utilities plus base body styling powered by the Aurora tokens
- rely on the single consolidated CSS entry from main.tsx to prevent missing Tailwind utilities

## Testing
- npm run lint:css *(fails: pre-existing indentation violations inside src/styles/grid-system.css)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aeb41c79c83209727381c4d101228)