### PR TITLE
Ensure roles and models load from static configs

### DIFF
--- a/src/__tests__/models-fallback.test.ts
+++ b/src/__tests__/models-fallback.test.ts
@@ -1,308 +1,98 @@
 /**
- * Model Fallback Strategy Tests
- *
- * Diese Test-Suite überprüft die Resilienz des Modell-Katalog-Systems
- * bei verschiedenen Fehlerszenarien wie Netzwerkausfällen, leeren
- * API-Antworten oder fehlenden Konfigurationsdateien.
- *
- * Test-Szenarien:
- * - Styles.json erfolgreich geladen
- * - Styles.json fehlgeschlagen, Fallback auf API
- * - Leere API-Antwort, Notfall-Fallback aktiviert
- * - Netzwerk-Timeouts werden gracefully behandelt
- * - Fehlformatierte Styles.json wird robust verarbeitet
+ * Modelle werden ausschließlich aus der statischen Konfiguration geladen.
+ * Diese Suite stellt sicher, dass /public/models.json die einzige Quelle ist
+ * und Fehlerszenarien sauber abgefangen werden.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { loadModelCatalog } from "../config/models";
-import { getRawModels } from "../services/openrouter";
 
-// Mock the OpenRouter service
-vi.mock("../services/openrouter", () => ({
-  getRawModels: vi.fn(),
-}));
-
-// Mock fetch for styles.json
 const mockFetch = vi.fn();
+
 global.fetch = mockFetch;
 
-/**
- * Haupt-Test-Suite für das Modell-Fallback-System
- *
- * Testet die mehrschichtige Fallback-Strategie des Modell-Katalogs,
- * die sicherstellt, dass das System immer brauchbare Modelle bereitstellt,
- * selbst wenn externe Ressourcen ausfallen.
- */
-describe("Model Fallback Strategy", () => {
+describe("loadModelCatalog", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockFetch.mockClear();
+    vi.resetAllMocks();
+    mockFetch.mockReset();
   });
 
-  /**
-   * Testet die mehrschichtige Fallback-Logik
-   *
-   * Prioritäten:
-   * 1. Styles.json (lokal oder remote)
-   * 2. API-Antwort von OpenRouter
-   * 3. Emergency-Fallback (harte Kodierung)
-   */
-  describe("Multi-layer fallback scenarios", () => {
-    /**
-     * Test: Styles.json erfolgreich laden
-     *
-     * Erwartet: Das System nutzt die in styles.json definierten Modelle
-     * und gibt sie korrekt zurück
-     */
-    it("should use styles.json when available", async () => {
-      // Mock successful styles.json fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => ({
-          styles: [
-            {
-              allow: ["meta-llama/llama-3.3-70b-instruct:free", "mistralai/mistral-nemo:free"],
-            },
-            {
-              allow: ["qwen/qwen-2.5-72b-instruct:free"],
-            },
-          ],
-        }),
-      });
-
-      // Mock OpenRouter API response
-      vi.mocked(getRawModels).mockResolvedValueOnce([
-        {
-          id: "meta-llama/llama-3.3-70b-instruct:free",
-          name: "Llama 3.3 70B",
-          tags: ["free"],
-        },
-        {
-          id: "mistralai/mistral-nemo:free",
-          name: "Mistral Nemo",
-          tags: ["free"],
-        },
-        {
-          id: "qwen/qwen-2.5-72b-instruct:free",
-          name: "Qwen 2.5 72B",
-          tags: ["free"],
-        },
-      ]);
-
-      const models = await loadModelCatalog();
-
-      expect(models).toHaveLength(3);
-      expect(models.map((m) => m.id)).toContain("meta-llama/llama-3.3-70b-instruct:free");
-      expect(models.map((m) => m.id)).toContain("mistralai/mistral-nemo:free");
-      expect(models.map((m) => m.id)).toContain("qwen/qwen-2.5-72b-instruct:free");
+  it("lädt und normalisiert Einträge aus models.json", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        await Promise.resolve();
+        return [
+          {
+            id: "openrouter/demo-free:free",
+            name: "Demo Free",
+            desc: "Kostenloses Testmodell",
+            price_in: 0,
+            price_out: 0,
+          },
+          {
+            id: "acme/paid-model",
+            name: "Acme Paid",
+            desc: "Premium Variante",
+            price_in: 0.1,
+            price_out: 0.2,
+          },
+        ];
+      },
     });
 
-    /**
-     * Test: Intelligenter Fallback bei styles.json-Fehlschlag
-     *
-     * Wenn styles.json nicht verfügbar ist, sollte das System intelligente
-     * Fallback-Logik verwenden, um passende Modelle aus der API-Antwort auszuwählen
-     */
-    it("should use intelligent fallback when styles.json fails", async () => {
-      // Mock failed styles.json fetch
-      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    const models = await loadModelCatalog();
 
-      // Mock successful OpenRouter API response
-      vi.mocked(getRawModels).mockResolvedValueOnce([
-        {
-          id: "meta-llama/llama-3.3-70b-instruct:free",
-          name: "Llama 3.3 70B",
-          tags: ["free"],
-        },
-        {
-          id: "mistralai/mistral-nemo:free",
-          name: "Mistral Nemo",
-          tags: ["free"],
-        },
-        {
-          id: "qwen/qwen-2.5-72b-instruct:free",
-          name: "Qwen 2.5 72B",
-          tags: ["free"],
-        },
-        {
-          id: "openai/gpt-4o-mini",
-          name: "GPT-4o Mini",
-          tags: [],
-        },
-      ]);
+    expect(mockFetch).toHaveBeenCalledWith("/models.json", { cache: "default" });
+    expect(models).toHaveLength(2);
+    const freeModel = models.find((m) => m.id === "openrouter/demo-free:free");
+    const paidModel = models.find((m) => m.id === "acme/paid-model");
 
-      const models = await loadModelCatalog();
-
-      // Should return intelligent fallback based on patterns
-      expect(models.length).toBeGreaterThan(0);
-
-      // Should prioritize free models
-      const freeModels = models.filter((m) => m.safety === "free");
-      expect(freeModels.length).toBeGreaterThan(0);
-
-      // Should include models from major providers
-      const hasLlama = models.some((m) => m.id.includes("meta-llama"));
-      const hasMistral = models.some((m) => m.id.includes("mistralai"));
-      expect(hasLlama || hasMistral).toBe(true);
+    expect(freeModel).toMatchObject({
+      id: "openrouter/demo-free:free",
+      label: "Demo Free",
+      safety: "free",
     });
-
-    /**
-     * Test: Statischer Notfall-Fallback bei komplettem Ausfall
-     *
-     * Wenn sowohl styles.json als auch die API fehlschlagen,
-     * sollte das System auf harte-kodierte Emergency-Fallback-Modelle
-     * zurückgreifen
-     */
-    it("should use static fallback when both styles.json and API fail", async () => {
-      // Mock failed styles.json fetch
-      mockFetch.mockRejectedValueOnce(new Error("Network error"));
-
-      // Mock failed OpenRouter API
-      vi.mocked(getRawModels).mockRejectedValueOnce(new Error("API error"));
-
-      const models = await loadModelCatalog();
-
-      // Should return emergency fallback models
-      expect(models.length).toBeGreaterThan(0);
-      expect(models.length).toBeLessThanOrEqual(5); // Should be limited set
-
-      // Should include at least one known free model
-      const hasKnownFreeModel = models.some(
-        (m) => m.id.includes("llama-3.3") || m.id.includes("mistral-nemo") || m.safety === "free",
-      );
-      expect(hasKnownFreeModel).toBe(true);
-    });
-
-    it("should handle intelligent pattern matching when exact models unavailable", async () => {
-      // Mock styles.json with specific models
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => ({
-          styles: [
-            {
-              allow: ["meta-llama/llama-3.3-70b-instruct:free"],
-            },
-          ],
-        }),
-      });
-
-      // Mock API with different but related models
-      vi.mocked(getRawModels).mockResolvedValueOnce([
-        {
-          id: "meta-llama/llama-3.3-70b-instruct", // Same but no :free suffix
-          name: "Llama 3.3 70B",
-          tags: [],
-        },
-        {
-          id: "meta-llama/llama-3.1-8b-instruct:free", // Different version
-          name: "Llama 3.1 8B",
-          tags: ["free"],
-        },
-      ]);
-
-      const models = await loadModelCatalog();
-
-      // Should find intelligent matches
-      expect(models.length).toBeGreaterThan(0);
-
-      // Should match by pattern
-      const hasLlamaMatch = models.some((m) => m.id.includes("meta-llama"));
-      expect(hasLlamaMatch).toBe(true);
-    });
-
-    /**
-     * Test: Notfall-Fallback bei leerer API-Antwort
-     *
-     * Sicherstellt, dass das System immer brauchbare Modelle bereitstellt,
-     * selbst wenn die API eine leere Antwort liefert
-     */
-    it("should provide meaningful fallback even with empty API response", async () => {
-      // Mock failed styles.json
-      mockFetch.mockRejectedValueOnce(new Error("styles.json not found"));
-
-      // Mock empty API response
-      vi.mocked(getRawModels).mockResolvedValueOnce([]);
-
-      const models = await loadModelCatalog();
-
-      // Should still provide emergency models
-      expect(models.length).toBeGreaterThan(0);
-      expect(models.every((m) => m.id && m.label)).toBe(true);
-
-      // Should have basic required properties
-      models.forEach((model) => {
-        expect(model.id).toBeTruthy();
-        expect(model.label).toBeTruthy();
-        expect(model.tags).toBeDefined();
-        expect(model.safety).toBeDefined();
-      });
+    expect(freeModel?.tags).toContain("free");
+    expect(freeModel?.pricing).toBeUndefined();
+    expect(paidModel).toMatchObject({
+      id: "acme/paid-model",
+      label: "Acme Paid",
+      description: "Premium Variante",
+      pricing: { in: 0.1, out: 0.2 },
+      safety: "moderate",
     });
   });
 
-  /**
-   * Testet Randfälle und Resilienz-Szenarien
-   *
-   * Diese Tests überprüfen, ob das System robust mit unerwarteten
-   * oder fehlerhaften Eingaben umgeht
-   */
-  describe("Resilience edge cases", () => {
-    /**
-     * Test: Fehlformatierte styles.json robust verarbeiten
-     *
-     * Stellt sicher, dass fehlerhafte JSON-Daten nicht zum Absturz
-     * des Systems führen, sondern ein Fallback ausgelöst wird
-     */
-    it("should handle malformed styles.json gracefully", async () => {
-      // Mock malformed styles.json
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => ({
-          // Missing styles array
-          invalid: "data",
-        }),
-      });
-
-      // Mock valid API response
-      vi.mocked(getRawModels).mockResolvedValueOnce([
-        {
-          id: "meta-llama/llama-3.3-70b-instruct:free",
-          name: "Llama 3.3 70B",
-          tags: ["free"],
-        },
-      ]);
-
-      const models = await loadModelCatalog();
-
-      // Should fall back to intelligent selection
-      expect(models.length).toBeGreaterThan(0);
+  it("gibt ein leeres Array zurück, wenn models.json leer ist", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        await Promise.resolve();
+        return [];
+      },
     });
 
-    /**
-     * Test: Netzwerk-Timeouts robust behandeln
-     *
-     * Überprüft, ob das System mit Netzwerk-Timeouts umgehen kann,
-     * ohne dass die Anwendung hängt oder abstürzt
-     */
-    it("should handle network timeouts gracefully", async () => {
-      // Mock timeout for styles.json
-      mockFetch.mockImplementationOnce(
-        () => new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 10)),
-      );
+    const models = await loadModelCatalog();
+    expect(models).toEqual([]);
+  });
 
-      // Mock fast API response
-      vi.mocked(getRawModels).mockResolvedValueOnce([
-        {
-          id: "mistralai/mistral-nemo:free",
-          name: "Mistral Nemo",
-          tags: ["free"],
-        },
-      ]);
-
-      const models = await loadModelCatalog();
-
-      // Should handle timeout and provide fallback
-      expect(models.length).toBeGreaterThan(0);
+  it("fängt HTTP-Fehler ab und liefert eine leere Liste", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
     });
+
+    const models = await loadModelCatalog();
+    expect(models).toEqual([]);
+  });
+
+  it("behandelt Netzwerkfehler und liefert eine leere Liste", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network down"));
+
+    const models = await loadModelCatalog();
+    expect(models).toEqual([]);
   });
 });

--- a/src/__tests__/roleStore.test.ts
+++ b/src/__tests__/roleStore.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+describe("roleStore", () => {
+  let mockFetch: FetchMock;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    mockFetch = vi.fn();
+    (global as any).fetch = mockFetch;
+
+    (global as any).localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+  });
+
+  it("lädt Rollen ausschließlich aus persona.json", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        await Promise.resolve();
+        return {
+          styles: [
+            {
+              id: "author",
+              name: "Author",
+              system: "Schreibe prägnant",
+              allow: ["openrouter/demo"],
+              tags: ["creative"],
+            },
+          ],
+        };
+      },
+    });
+
+    const { fetchRoleTemplates, getRoleState } = await import("../config/roleStore");
+
+    const roles = await fetchRoleTemplates(true);
+
+    expect(mockFetch).toHaveBeenCalledWith("/persona.json", { cache: "no-store" });
+    expect(roles).toEqual([
+      {
+        id: "author",
+        name: "Author",
+        system: "Schreibe prägnant",
+        allow: ["openrouter/demo"],
+        tags: ["creative"],
+      },
+    ]);
+    expect(getRoleState().state).toBe("ok");
+  });
+
+  it("meldet missing, wenn persona.json nicht geladen werden kann", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network down"));
+
+    const { fetchRoleTemplates, getRoleState } = await import("../config/roleStore");
+
+    const roles = await fetchRoleTemplates(true);
+
+    expect(roles).toEqual([]);
+    expect(getRoleState().state).toBe("missing");
+    expect(getRoleState().error).toContain("persona.json");
+  });
+});

--- a/src/config/roleStore.ts
+++ b/src/config/roleStore.ts
@@ -74,24 +74,19 @@ async function fetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
 }
 
 async function tryLoadRoles(signal?: AbortSignal): Promise<RoleTemplate[] | null> {
-  const candidates = ["/styles.json", "/persona.json", "/roles.json"];
-  for (const url of candidates) {
-    try {
-      const data = await fetchJson(url, signal);
-      if (!data) continue;
-      const arr = Array.isArray(data)
-        ? data
-        : Array.isArray((data as Record<string, unknown>)["styles"])
-          ? ((data as Record<string, unknown>)["styles"] as unknown[])
-          : null;
-      if (!arr) continue;
-      const parsed = parseRoles(arr);
-      if (parsed && parsed.length > 0) return sanitize(parsed);
-    } catch {
-      // next candidate
-    }
+  try {
+    const data = await fetchJson("/persona.json", signal);
+    const arr = Array.isArray(data)
+      ? data
+      : Array.isArray((data as Record<string, unknown>)["styles"])
+        ? ((data as Record<string, unknown>)["styles"] as unknown[])
+        : null;
+    if (!arr) return null;
+    const parsed = parseRoles(arr);
+    return parsed && parsed.length > 0 ? sanitize(parsed) : null;
+  } catch {
+    return null;
   }
-  return null;
 }
 
 /* -------------------- Public API -------------------- */
@@ -135,7 +130,7 @@ export async function fetchRoleTemplates(
         _roles = [];
         _loaded = true;
         _state = "missing";
-        _error = "styles.json nicht gefunden oder ungültig (public/styles.json)";
+        _error = "persona.json nicht gefunden oder ungültig (public/persona.json)";
         return _roles;
       }
       _roles = list;


### PR DESCRIPTION
## Summary
- load role templates exclusively from public/persona.json and report missing persona errors clearly
- refresh model loading tests to assert models.json is the only catalogue source
- add coverage for roleStore loading from persona.json

## Testing
- npm run test:unit -- src/__tests__/models-fallback.test.ts src/__tests__/roleStore.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f22a2e90883209a89097285e95b11)