### PR TITLE
Update model catalog and metrics display

### DIFF
--- a/public/models.json
+++ b/public/models.json
@@ -1,198 +1,142 @@
 [
   {
-    "id": "openrouter/andromeda-alpha",
-    "name": "Andromeda Alpha",
-    "desc": "Versteht Text und Bilder, erklärt Inhalte visuell.",
+    "id": "deepseek/deepseek-chat-v3-0324:free",
+    "name": "DeepSeek Chat V3 (0324)",
+    "desc": "Sehr starkes Chat-Flaggschiff, gut für lange Diskussionen, weitgehend frei im Ton.",
     "price_in": 0.0,
-    "price_out": 0.0
+    "price_out": 0.0,
+    "context_tokens": 163840,
+    "context_k": 164,
+    "quality_score": 85,
+    "censor_score": 35,
+    "openness": 0.65,
+    "tags": ["chat", "discussion", "long_context", "balanced", "multilingual"],
+    "notes": "Top Default für Diskussionen."
   },
   {
-    "id": "alibaba/tongyi-deepresearch-30b-a3b:free",
-    "name": "Tongyi DeepResearch 30B",
-    "desc": "Denkt logisch und gründlich, ideal für lange Fragen.",
+    "id": "qwen/qwen3-235b-a22b-2507:free",
+    "name": "Qwen3 235B A22B Instruct (2507)",
+    "desc": "Extrem großer Allround-Chatbot, sehr stabil, stark im Argumentieren.",
     "price_in": 0.0,
-    "price_out": 0.0
+    "price_out": 0.0,
+    "context_tokens": 262144,
+    "context_k": 262,
+    "quality_score": 84,
+    "censor_score": 50,
+    "openness": 0.5,
+    "tags": ["chat", "discussion", "ultra_long_context", "multilingual", "reasoning"],
+    "notes": "Wenn du richtig lange Threads willst."
+  },
+  {
+    "id": "meta-llama/llama-3.3-70b-instruct:free",
+    "name": "Llama 3.3 70B Instruct",
+    "desc": "Sehr natürliches Dialogmodell, strukturiert, zuverlässig.",
+    "price_in": 0.0,
+    "price_out": 0.0,
+    "context_tokens": 131072,
+    "context_k": 131,
+    "quality_score": 82,
+    "censor_score": 55,
+    "openness": 0.45,
+    "tags": ["chat", "discussion", "multilingual", "reliable"],
+    "notes": "Solider Diskussions-Partner, eher 'standard-safe'."
+  },
+  {
+    "id": "mistralai/mistral-small-3.2-24b-instruct:free",
+    "name": "Mistral Small 3.2 24B",
+    "desc": "Schnell, klar, gut in Mehrfach-Dialogen ohne nervige Aussetzer.",
+    "price_in": 0.0,
+    "price_out": 0.0,
+    "context_tokens": 131072,
+    "context_k": 131,
+    "quality_score": 80,
+    "censor_score": 45,
+    "openness": 0.55,
+    "tags": ["chat", "discussion", "fast", "multilingual"],
+    "notes": "Guter Mix aus Tempo und Gesprächsqualität."
   },
   {
     "id": "meituan/longcat-flash-chat:free",
-    "name": "Longcat Flash Chat",
-    "desc": "Sehr schnelles Chat-Modell, merkt sich lange Gespräche.",
+    "name": "LongCat Flash Chat",
+    "desc": "Sehr schnelles MoE-Chatmodell, überraschend gut bei längeren Diskussionen.",
     "price_in": 0.0,
-    "price_out": 0.0
+    "price_out": 0.0,
+    "context_tokens": 131072,
+    "context_k": 128,
+    "quality_score": 77,
+    "censor_score": 45,
+    "openness": 0.55,
+    "tags": ["chat", "discussion", "fast", "long_context"],
+    "notes": "Fallback, wenn du Speed willst."
   },
   {
-    "id": "deepseek/deepseek-chat-v3-0324:free",
-    "name": "Deepseek Chat V3",
-    "desc": "Redet natürlich, kann aber auch nachdenken, wenn nötig.",
+    "id": "meta-llama/llama-3.3-8b-instruct:free",
+    "name": "Llama 3.3 8B Instruct",
+    "desc": "Kleiner Bruder vom 70B: flott, sauber, aber weniger tief.",
     "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-    "name": "Dolphin Mistral Venice",
-    "desc": "Sehr freies Modell ohne starke Filter, kreativ und offen.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "tencent/hunyuan-a13b-instruct:free",
-    "name": "Hunyuan A13B",
-    "desc": "Allrounder für Gespräche und Erklärungen, ruhig und klar.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "deepseek/deepseek-r1-0528-qwen3-8b:free",
-    "name": "Deepseek R1 Qwen 8B",
-    "desc": "Kleines, logisches Modell, das gut nachdenkt.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "google/gemma-3n-e4b-it:free",
-    "name": "Gemma 3N 4B",
-    "desc": "Leichtes Modell, läuft schnell und spart Ressourcen.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "qwen/qwen3-8b:free",
-    "name": "Qwen 3 8B",
-    "desc": "Freundlicher Mehrsprachler mit klarem Schreibstil.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "shisa-ai/shisa-v2-llama3.3-70b:free",
-    "name": "Shisa Llama 3.3 70B",
-    "desc": "Stark in Japanisch und Englisch, natürlich und höflich.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "arliai/qwq-32b-arliai-rpr-v1:free",
-    "name": "QwQ 32B Arliai",
-    "desc": "Kreatives Modell für Geschichten oder Rollenspiele.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "venice/uncensored:free",
-    "name": "Venice Uncensored",
-    "desc": "Redet frei und ungefiltert, ideal für ehrliche Gespräche.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "nvidia/nemotron-nano-9b-v2:free",
-    "name": "Nemotron Nano 9B",
-    "desc": "Schnell und leicht, versteht einfache Logik.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "z-ai/glm-4-32b",
-    "name": "GLM 4 32B",
-    "desc": "Versteht lange Texte gut und bleibt konzentriert.",
-    "price_in": 0.1,
-    "price_out": 0.1
-  },
-  {
-    "id": "opengvlab/internvl3-78b",
-    "name": "InternVL3 78B",
-    "desc": "Kann Bilder und Text gemeinsam analysieren.",
-    "price_in": 0.07,
-    "price_out": 0.26
-  },
-  {
-    "id": "arcee-ai/afm-4.5b",
-    "name": "AFM 4.5B",
-    "desc": "Kleines, stabiles Modell für einfache Aufgaben.",
-    "price_in": 0.05,
-    "price_out": 0.15
-  },
-  {
-    "id": "baidu/ernie-4.5-21b-a3b",
-    "name": "Ernie 4.5 21B",
-    "desc": "Sehr gut bei logischem Denken und längeren Themen.",
-    "price_in": 0.07,
-    "price_out": 0.28
-  },
-  {
-    "id": "openai/gpt-oss-20b",
-    "name": "GPT OSS 20B",
-    "desc": "Offenes OpenAI-Modell, vielseitig und stabil.",
-    "price_in": 0.03,
-    "price_out": 0.14
-  },
-  {
-    "id": "qwen/qwen-2.5-72b-instruct",
-    "name": "Qwen 2.5 72B",
-    "desc": "Starker Allrounder für lange, natürliche Chats.",
-    "price_in": 0.07,
-    "price_out": 0.26
-  },
-  {
-    "id": "x-ai/grok-4-fast",
-    "name": "Grok 4 Fast",
-    "desc": "Antwortet schnell und kann viel Kontext behalten.",
-    "price_in": 0.2,
-    "price_out": 0.5
-  },
-  {
-    "id": "deepseek/deepseek-chat",
-    "name": "Deepseek Chat",
-    "desc": "Standardmodell, freundlich und zuverlässig.",
-    "price_in": 0.24,
-    "price_out": 0.84
-  },
-  {
-    "id": "meta-llama/llama-4-maverick",
-    "name": "Llama 4 Maverick",
-    "desc": "Großes Modell für vielseitige Gespräche.",
-    "price_in": 0.15,
-    "price_out": 0.6
-  },
-  {
-    "id": "meta-llama/llama-3.1-70b-instruct",
-    "name": "Llama 3.1 70B",
-    "desc": "Bewährtes Chat-Modell mit klaren Antworten.",
-    "price_in": 0.4,
-    "price_out": 0.4
-  },
-  {
-    "id": "mistralai/mistral-nemo",
-    "name": "Mistral Nemo",
-    "desc": "Sehr günstig und flink im Gespräch.",
-    "price_in": 0.02,
-    "price_out": 0.04
-  },
-  {
-    "id": "mistralai/mistral-7b-instruct-v0.3",
-    "name": "Mistral 7B",
-    "desc": "Kleines, schnelles Modell für kurze Chats.",
-    "price_in": 0.03,
-    "price_out": 0.05
-  },
-  {
-    "id": "z-ai/glm-4.5-air:free",
-    "name": "GLM 4.5 Air",
-    "desc": "Leichtes Modell mit optionalem Denkmodus.",
-    "price_in": 0.0,
-    "price_out": 0.0
-  },
-  {
-    "id": "tngtech/deepseek-r1t2-chimera:free",
-    "name": "Deepseek R1T2 Chimera",
-    "desc": "Kombiniert zwei Denkmodelle, gut bei Problemlösungen.",
-    "price_in": 0.0,
-    "price_out": 0.0
+    "price_out": 0.0,
+    "context_tokens": 128000,
+    "context_k": 128,
+    "quality_score": 72,
+    "censor_score": 55,
+    "openness": 0.45,
+    "tags": ["chat", "discussion", "fast", "lightweight"],
+    "notes": "Für schnelle kurze Diskussionen."
   },
   {
     "id": "google/gemma-3-27b-it:free",
-    "name": "Gemma 3 27B",
-    "desc": "Großes, freundliches Modell für vielseitige Chats.",
+    "name": "Gemma 3 27B IT",
+    "desc": "Freundliches, ordentliches Dialogmodell. Eher vorsichtig bei heiklen Themen.",
     "price_in": 0.0,
-    "price_out": 0.0
+    "price_out": 0.0,
+    "context_tokens": 131072,
+    "context_k": 131,
+    "quality_score": 78,
+    "censor_score": 65,
+    "openness": 0.35,
+    "tags": ["chat", "discussion", "polite", "multilingual"],
+    "notes": "Sauberer Ton, aber klar mehr Filter."
+  },
+  {
+    "id": "mistralai/mistral-7b-instruct:free",
+    "name": "Mistral 7B Instruct",
+    "desc": "Kleines, flinkes Modell für kurze Dialoge und leichte Diskussionen.",
+    "price_in": 0.0,
+    "price_out": 0.0,
+    "context_tokens": 32768,
+    "context_k": 33,
+    "quality_score": 70,
+    "censor_score": 45,
+    "openness": 0.55,
+    "tags": ["chat", "discussion", "small", "fast"],
+    "notes": "Kleines, flinkes Modell für kurze Dialoge und leichte Diskussionen."
+  },
+  {
+    "id": "tencent/hunyuan-a13b-instruct:free",
+    "name": "Hunyuan A13B Instruct",
+    "desc": "Allround-Chat, ruhig im Stil, gute Erklärungen.",
+    "price_in": 0.0,
+    "price_out": 0.0,
+    "context_tokens": 32768,
+    "context_k": 33,
+    "quality_score": 74,
+    "censor_score": 50,
+    "openness": 0.5,
+    "tags": ["chat", "discussion", "balanced", "multilingual"],
+    "notes": "Solider Free-Allrounder."
+  },
+  {
+    "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+    "name": "Dolphin Mistral 24B Venice (Uncensored)",
+    "desc": "Sehr offen/ungefiltert. Gut für kontroverse Diskussionen, aber braucht deine Leitplanken.",
+    "price_in": 0.0,
+    "price_out": 0.0,
+    "context_tokens": 32768,
+    "context_k": 33,
+    "quality_score": 76,
+    "censor_score": 10,
+    "openness": 0.9,
+    "tags": ["chat", "discussion", "uncensored", "roleplay"],
+    "notes": "NoFilter-Slot. Deutlich markieren."
   }
 ]

--- a/src/components/models/ModelComparisonTable.tsx
+++ b/src/components/models/ModelComparisonTable.tsx
@@ -8,6 +8,25 @@ interface ModelComparisonTableProps {
 }
 
 export function ModelComparisonTable({ models }: ModelComparisonTableProps) {
+  const formatContext = (model: EnhancedModel) => {
+    const contextK =
+      model.contextK ??
+      (model.context.maxTokens ? Math.round(model.context.maxTokens / 1024) : undefined);
+    return contextK ? `${contextK}K` : "N/A";
+  };
+
+  const formatOpenness = (model: EnhancedModel) => {
+    const openness =
+      model.openness ??
+      (typeof model.censorScore === "number" ? 1 - model.censorScore / 100 : undefined);
+    return typeof openness === "number" ? `${Math.round(openness * 100)}%` : "N/A";
+  };
+
+  const formatQuality = (model: EnhancedModel) => {
+    const quality = model.qualityScore ?? model.performance.quality;
+    return `${Math.round(quality)}/100`;
+  };
+
   const properties = [
     { label: "Anbieter", getValue: (model: EnhancedModel) => model.provider },
     {
@@ -16,19 +35,15 @@ export function ModelComparisonTable({ models }: ModelComparisonTableProps) {
     },
     {
       label: "Qualität",
-      getValue: (model: EnhancedModel) => `${model.performance.quality}/10`,
+      getValue: (model: EnhancedModel) => formatQuality(model),
     },
     {
-      label: "Geschwindigkeit",
-      getValue: (model: EnhancedModel) => `${model.performance.speed}/10`,
+      label: "Kontext",
+      getValue: (model: EnhancedModel) => formatContext(model),
     },
     {
-      label: "Kosten",
-      getValue: (model: EnhancedModel) => `${model.performance.efficiency}/10`,
-    },
-    {
-      label: "Verfügbarkeit",
-      getValue: (model: EnhancedModel) => `${model.performance.reliability}/10`,
+      label: "Offenheit",
+      getValue: (model: EnhancedModel) => formatOpenness(model),
     },
     {
       label: "Tags",

--- a/src/types/enhanced-interfaces.ts
+++ b/src/types/enhanced-interfaces.ts
@@ -73,6 +73,10 @@ export interface EnhancedModel {
     effectiveTokens?: number; // real-world usable context
   };
 
+  // Optional raw context meta for UI badges
+  contextK?: number;
+  contextTokens?: number;
+
   // NEW: Performance Scores (0-100 scale)
   performance: {
     speed: number; // Response time score
@@ -81,10 +85,18 @@ export interface EnhancedModel {
     efficiency: number; // Cost/performance ratio
   };
 
+  // Optional quality/openness scores from catalog
+  qualityScore?: number;
+  openness?: number;
+  censorScore?: number;
+
   // Enhanced tags and categorization
   tags: string[];
   category: ModelCategory;
   tier: "free" | "budget" | "premium" | "enterprise";
+
+  // Optional catalog notes
+  notes?: string;
 
   // NEW: Favorites & Usage System
   isFavorite: boolean;

--- a/src/ui/ModelCard.tsx
+++ b/src/ui/ModelCard.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/ui/Badge";
 import { PremiumCard } from "@/ui/PremiumCard";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/ui/Tooltip";
 
-import { Star } from "../lib/icons";
+import { Info, Star } from "../lib/icons";
 
 /**
  * ModelCard - Premium Material Design mit Unified Lila Metrics
@@ -19,12 +20,13 @@ import { Star } from "../lib/icons";
 interface ModelCardProps {
   name: string;
   vendor: string;
-  speed: number;
   quality: number;
-  value: number;
+  contextScore: number;
+  openness: number;
   isFree: boolean;
   price: string;
   contextLength: string;
+  notes?: string;
   isFavorite?: boolean;
   onToggleFavorite?: () => void;
   isActive?: boolean;
@@ -36,115 +38,135 @@ const ModelCardComponent = React.memo(
   ({
     name,
     vendor,
-    speed,
     quality,
-    value,
+    contextScore,
+    openness,
     isFree,
     price,
     contextLength,
+    notes,
     isFavorite = false,
     isActive = false,
     onToggleFavorite,
     className,
     onCardClick,
   }: ModelCardProps) => {
+    const metrics = [
+      { label: "Qualität", val: quality },
+      { label: "Kontext", val: contextScore },
+      {
+        label: "Offenheit",
+        val: openness,
+        tooltip:
+          "Hohe Offenheit = weniger automatische Ablehnung. Faktencheck bleibt trotzdem aktiv.",
+      },
+    ];
+
     return (
       <PremiumCard
         onClick={onCardClick}
         className={cn("group", isActive && "ring-2 ring-brand shadow-raiseLg", className)}
       >
-        <div className="space-y-3">
-          {/* Row 1: Name + Badges */}
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex-1 min-w-0">
-              <h3 className="text-base font-semibold text-text-primary truncate">{name}</h3>
-              <p className="text-xs text-text-muted font-medium uppercase tracking-wider mt-0.5">
-                {vendor}
-              </p>
-            </div>
-            <div className="flex items-center gap-1.5 flex-shrink-0">
-              {isActive && (
+        <TooltipProvider>
+          <div className="space-y-3">
+            {/* Row 1: Name + Badges */}
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <h3 className="text-base font-semibold text-text-primary truncate">{name}</h3>
+                <p className="text-xs text-text-muted font-medium uppercase tracking-wider mt-0.5">
+                  {vendor}
+                </p>
+              </div>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                {isActive && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[11px] font-semibold bg-brand/10 text-brand border-brand/40"
+                  >
+                    Aktiv
+                  </Badge>
+                )}
+                {isFavorite && (
+                  <div className="w-5 h-5 rounded-full bg-brand/10 flex items-center justify-center">
+                    <Star className="h-3 w-3 fill-brand text-brand" />
+                  </div>
+                )}
                 <Badge
                   variant="secondary"
-                  className="text-[11px] font-semibold bg-brand/10 text-brand border-brand/40"
+                  className={cn(
+                    "px-2 py-0.5 text-xs font-semibold rounded-sm shadow-raise",
+                    isFree
+                      ? "bg-accent-secondary/15 text-accent-secondary"
+                      : "bg-brand/15 text-brand-bright",
+                  )}
                 >
-                  Aktiv
+                  {isFree ? "FREE" : price}
                 </Badge>
-              )}
-              {isFavorite && (
-                <div className="w-5 h-5 rounded-full bg-brand/10 flex items-center justify-center">
-                  <Star className="h-3 w-3 fill-brand text-brand" />
-                </div>
-              )}
-              <Badge
-                variant="secondary"
-                className={cn(
-                  "px-2 py-0.5 text-xs font-semibold rounded-sm shadow-raise",
-                  isFree
-                    ? "bg-accent-secondary/15 text-accent-secondary"
-                    : "bg-brand/15 text-brand-bright",
-                )}
-              >
-                {isFree ? "FREE" : price}
-              </Badge>
-            </div>
-          </div>
-
-          {/* Row 2: Unified Lila Metrics (SIGNATURE ELEMENT) */}
-          <div className="space-y-2 bg-surface-inset shadow-inset p-3 rounded-md">
-            {[
-              { label: "Speed", val: speed },
-              { label: "Quality", val: quality },
-              { label: "Value", val: value },
-            ].map(({ label, val }) => (
-              <div key={label} className="flex items-center gap-2.5">
-                <span className="text-xs font-medium text-text-secondary w-12 flex-shrink-0">
-                  {label}
-                </span>
-                <div
-                  className="flex-1 h-1.5 rounded-full overflow-hidden"
-                  style={{ backgroundColor: "var(--metric-gradient-bg)" }}
-                >
-                  <div
-                    className="h-full rounded-full bg-metric-gradient transition-all duration-300 shadow-brandGlow"
-                    style={{ width: `${val}%` }}
-                  />
-                </div>
-                <span className="text-xs font-bold text-text-primary w-7 text-right flex-shrink-0">
-                  {val}
-                </span>
               </div>
-            ))}
-          </div>
+            </div>
 
-          {/* Row 3: Context Length + Favorite Action */}
-          <div className="flex items-center justify-between pt-1">
-            <Badge
-              variant="outline"
-              className="text-xs px-2 py-1 bg-surface-1 shadow-raise rounded-sm"
-            >
-              {contextLength}
-            </Badge>
+            {/* Row 2: Metrics */}
+            <div className="space-y-2 bg-surface-inset shadow-inset p-3 rounded-md">
+              {metrics.map(({ label, val, tooltip }) => (
+                <div key={label} className="flex items-center gap-2.5">
+                  <div className="flex items-center gap-1 w-16 flex-shrink-0">
+                    <span className="text-xs font-medium text-text-secondary">{label}</span>
+                    {tooltip && (
+                      <Tooltip delayDuration={200}>
+                        <TooltipTrigger asChild>
+                          <Info className="h-3.5 w-3.5 text-text-muted" />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-[220px] text-xs">{tooltip}</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                  <div
+                    className="flex-1 h-1.5 rounded-full overflow-hidden"
+                    style={{ backgroundColor: "var(--metric-gradient-bg)" }}
+                  >
+                    <div
+                      className="h-full rounded-full bg-metric-gradient transition-all duration-300 shadow-brandGlow"
+                      style={{ width: `${val}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-bold text-text-primary w-10 text-right flex-shrink-0">
+                    {Math.round(val)}
+                  </span>
+                </div>
+              ))}
+            </div>
 
-            {onToggleFavorite && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleFavorite();
-                }}
-                className={cn(
-                  "p-2 rounded-sm transition-all duration-fast",
-                  isFavorite
-                    ? "bg-brand/10 text-brand shadow-brandGlow"
-                    : "text-text-muted hover:bg-surface-1 hover:text-brand hover:shadow-raise active:scale-95",
-                )}
-                aria-label={isFavorite ? "Favorit entfernen" : "Als Favorit markieren"}
+            {/* Row 3: Context Length + Favorite Action */}
+            <div className="flex items-center justify-between pt-1 gap-2">
+              <Badge
+                variant="outline"
+                className="text-xs px-2 py-1 bg-surface-1 shadow-raise rounded-sm"
               >
-                <Star className={cn("h-4 w-4", isFavorite && "fill-brand")} />
-              </button>
-            )}
+                Kontext: {contextLength}
+              </Badge>
+
+              {onToggleFavorite && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleFavorite();
+                  }}
+                  className={cn(
+                    "p-2 rounded-sm transition-all duration-fast",
+                    isFavorite
+                      ? "bg-brand/10 text-brand shadow-brandGlow"
+                      : "text-text-muted hover:bg-surface-1 hover:text-brand hover:shadow-raise active:scale-95",
+                  )}
+                  aria-label={isFavorite ? "Favorit entfernen" : "Als Favorit markieren"}
+                >
+                  <Star className={cn("h-4 w-4", isFavorite && "fill-brand")} />
+                </button>
+              )}
+            </div>
+
+            {notes && <p className="text-xs text-text-secondary leading-snug">{notes}</p>}
           </div>
-        </div>
+        </TooltipProvider>
       </PremiumCard>
     );
   },


### PR DESCRIPTION
## Summary
- replace the models catalog with OpenRouter-aligned entries that include context, quality, censoring, and openness metadata
- extend model typing and enhanced model mapping to carry the new scores and context information through the app
- refresh the models UI to show Qualität, Kontext, and Offenheit with formatted context badges and openness tooltip text

## Testing
- npm run verify
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692449e3cd1c8320811e368d0b5b764a)