### PR TITLE
Fix MaterialCard spine support for chat usage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@use-gesture/react':
+        specifier: ^10.3.1
+        version: 10.3.1(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2567,6 +2570,14 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -9057,6 +9068,13 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@18.3.1)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 18.3.1
 
   '@vitejs/plugin-react@4.7.0(vite@7.2.4(@types/node@24.10.1)(jiti@1.21.7)(terser@5.44.1)(yaml@2.8.1))':
     dependencies:

--- a/src/components/navigation/Bookmark.tsx
+++ b/src/components/navigation/Bookmark.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { cn } from "@/lib/utils";
 
 interface BookmarkProps {
@@ -18,7 +16,7 @@ export function Bookmark({ onClick, className }: BookmarkProps) {
         "flex items-center justify-center",
         "transition-transform hover:translate-y-1 active:translate-y-2",
         "clip-path-bookmark", // We need to define this or use SVG
-        className
+        className,
       )}
       style={{
         clipPath: "polygon(0 0, 100% 0, 100% 100%, 50% 85%, 0 100%)",
@@ -31,7 +29,11 @@ export function Bookmark({ onClick, className }: BookmarkProps) {
         fill="currentColor"
         className="w-4 h-4 sm:w-5 sm:h-5 text-white/90"
       >
-        <path fillRule="evenodd" d="M6.32 2.577a49.255 49.255 0 0111.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 01-1.085.67L12 18.089l-7.165 3.583A.75.75 0 013.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93z" clipRule="evenodd" />
+        <path
+          fillRule="evenodd"
+          d="M6.32 2.577a49.255 49.255 0 0111.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 01-1.085.67L12 18.089l-7.165 3.583A.75.75 0 013.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93z"
+          clipRule="evenodd"
+        />
       </svg>
     </button>
   );

--- a/src/components/navigation/HistorySidePanel.tsx
+++ b/src/components/navigation/HistorySidePanel.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { X } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/Button";
@@ -59,7 +57,7 @@ export function HistorySidePanel({
                     "w-full text-left p-3 rounded-lg border transition-colors",
                     activeChatId === page.id
                       ? "bg-accent/10 border-accent text-accent"
-                      : "bg-surface-2 border-transparent hover:bg-surface-3 text-text-primary"
+                      : "bg-surface-2 border-transparent hover:bg-surface-3 text-text-primary",
                   )}
                 >
                   <div className="font-medium truncate">{page.title}</div>
@@ -73,25 +71,25 @@ export function HistorySidePanel({
 
           {/* Archived Pages */}
           <section>
-             <h3 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
+            <h3 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
               Alle Chats
             </h3>
             <div className="space-y-1">
               {archivedPages.map((page) => (
                 <button
-                   key={page.id}
-                   onClick={() => {
-                     onSelectChat(page.id);
-                     onClose();
-                   }}
-                   className="w-full text-left p-3 rounded-lg hover:bg-surface-2 transition-colors flex justify-between items-center group"
+                  key={page.id}
+                  onClick={() => {
+                    onSelectChat(page.id);
+                    onClose();
+                  }}
+                  className="w-full text-left p-3 rounded-lg hover:bg-surface-2 transition-colors flex justify-between items-center group"
                 >
-                   <div className="truncate flex-1 pr-4">
-                     <div className="text-text-primary group-hover:text-accent transition-colors">
-                       {page.title}
-                     </div>
-                     <div className="text-xs text-text-secondary">{page.date}</div>
-                   </div>
+                  <div className="truncate flex-1 pr-4">
+                    <div className="text-text-primary group-hover:text-accent transition-colors">
+                      {page.title}
+                    </div>
+                    <div className="text-xs text-text-secondary">{page.date}</div>
+                  </div>
                 </button>
               ))}
             </div>

--- a/src/ui/MaterialCard.tsx
+++ b/src/ui/MaterialCard.tsx
@@ -5,6 +5,10 @@ import { cn } from "@/lib/utils";
 interface MaterialCardProps extends ComponentProps<"div"> {
   children: ReactNode;
   variant?: "raised" | "inset" | "hero";
+  /**
+   * Optional decorative spine to visually align the card to one side.
+   */
+  spineSide?: "left" | "right";
 }
 
 /**
@@ -20,7 +24,13 @@ interface MaterialCardProps extends ComponentProps<"div"> {
  * - "inset": Inset appearance for input areas
  * - "hero": Elevated shadow for focal elements
  */
-export function MaterialCard({ children, className, variant = "raised", ...props }: MaterialCardProps) {
+export function MaterialCard({
+  children,
+  className,
+  variant = "raised",
+  spineSide,
+  ...props
+}: MaterialCardProps) {
   const baseStyles = "relative rounded-md p-6 transition-shadow duration-fast";
 
   const variantStyles = {
@@ -34,10 +44,13 @@ export function MaterialCard({ children, className, variant = "raised", ...props
       className={cn(
         baseStyles,
         variantStyles[variant],
+        spineSide === "left" && "border-l-4 border-surface-3 pl-5",
+        spineSide === "right" && "border-r-4 border-surface-3 pr-5",
         // Ensure scrollability when interactive
         props.onClick && "[touch-action:pan-y] cursor-pointer",
         className,
       )}
+      data-spine-side={spineSide}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- extend MaterialCard to support optional spine-side styling used by chat bubbles
- remove unused React imports in navigation components
- update lockfile with @use-gesture/react dependency entries

## Testing
- npm run verify


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a04e5021c8320af777378636b7b1c)