### PR TITLE
Handle base URL for routing and service workers

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -172,6 +172,7 @@ export const appRouter = createBrowserRouter(
     },
   ],
   {
+    basename: import.meta.env.BASE_URL ?? "/",
     future: {
       v7_skipActionErrorRevalidation: true,
       v7_normalizeFormMethod: true,


### PR DESCRIPTION
## Summary
- surface missing environment variables with a visible overlay during initialization
- configure the router basename from `import.meta.env.BASE_URL` to support subpath deployments
- align service worker registration and cache warmup with the validated `VITE_BASE_URL`

## Testing
- npm run verify
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e5068371883209f3538d1c62258a6)