### PR TITLE
Improve loading fallbacks and error UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ToastsProvider } from "@/ui/toast";
 import { TooltipProvider } from "@/ui/Tooltip";
 
 import { Router } from "./app/router";
+import { FullPageLoader } from "./components/FullPageLoader";
 import { OnboardingOverlay } from "./components/onboarding/OnboardingOverlay";
 import { FavoritesProvider } from "./contexts/FavoritesContext";
 import { RolesProvider } from "./contexts/RolesContext";
@@ -65,6 +66,20 @@ function AppContent() {
                   Entschuldigung, es ist ein unerwarteter Fehler aufgetreten. Das Problem wurde
                   automatisch gemeldet.
                 </p>
+                <p className="mt-3 text-sm text-text-secondary">
+                  <a
+                    className="text-accent hover:underline"
+                    href="#"
+                    onClick={() => window.location.reload()}
+                  >
+                    Neu laden
+                  </a>{" "}
+                  oder wende dich an unseren Support unter{" "}
+                  <a className="text-accent hover:underline" href="mailto:support@disa.ai">
+                    support@disa.ai
+                  </a>
+                  , falls das Problem bestehen bleibt.
+                </p>
               </div>
               <div className="mt-6 flex flex-col gap-3">
                 <Button onClick={resetError} variant="primary" className="w-full">
@@ -93,9 +108,11 @@ function AppContent() {
         )}
         showDialog={false}
       >
-        <Router />
+        <Suspense fallback={<FullPageLoader message="Inhalt wird geladen" />}>
+          <Router />
+        </Suspense>
       </SentryErrorBoundary>
-      <Suspense fallback={null}>
+      <Suspense fallback={<FullPageLoader message="Einstellungen werden geladen" />}>
         <FeatureFlagPanel />
       </Suspense>
       {!settings.hasCompletedOnboarding && <OnboardingOverlay onComplete={completeOnboarding} />}

--- a/src/app/components/RouteWrapper.tsx
+++ b/src/app/components/RouteWrapper.tsx
@@ -1,21 +1,14 @@
 import { type ReactNode, Suspense } from "react";
 
 import { ErrorBoundary } from "../../components/ErrorBoundary";
+import { FullPageLoader } from "../../components/FullPageLoader";
 import { AppShell } from "../layouts/AppShell";
-
-function SimpleLoader() {
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--accent)]"></div>
-    </div>
-  );
-}
 
 export function RouteWrapper({ children }: { children: ReactNode }) {
   return (
     <AppShell>
       <ErrorBoundary>
-        <Suspense fallback={<SimpleLoader />}>{children}</Suspense>
+        <Suspense fallback={<FullPageLoader message="Seite wird geladen" />}>{children}</Suspense>
       </ErrorBoundary>
     </AppShell>
   );

--- a/src/components/FullPageLoader.tsx
+++ b/src/components/FullPageLoader.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+interface FullPageLoaderProps {
+  message?: string;
+  actionHint?: ReactNode;
+}
+
+export function FullPageLoader({ message = "Ladevorgang läuft", actionHint }: FullPageLoaderProps) {
+  return (
+    <div
+      className="bg-surface-base flex min-h-screen items-center justify-center px-4"
+      aria-busy="true"
+    >
+      <div className="bg-surface-2 shadow-raise flex w-full max-w-sm flex-col items-center gap-4 rounded-2xl p-6 text-center">
+        <div className="flex w-full items-center gap-4">
+          <div
+            className="border-border/40 text-accent h-12 w-12 animate-spin rounded-full border-4 border-t-current"
+            aria-hidden="true"
+          />
+          <div className="flex-1 space-y-2">
+            <div className="bg-surface-subtle h-3 w-20 animate-pulse rounded-full" />
+            <div className="bg-surface-subtle h-3 w-28 animate-pulse rounded-full" />
+          </div>
+        </div>
+        <p className="text-text-secondary text-sm">{message}</p>
+        {actionHint}
+        <span className="sr-only" role="status" aria-live="polite">
+          {message}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable full-page loader with accessible live status messaging for suspense fallbacks
- show loaders while router and route wrappers await lazy chunks to keep navigation responsive
- expand error boundary fallback with reload link and support hint for recovery guidance

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e506960a88320b6a60ffe9309cb16)