### PR TITLE
feat(ui): apply nightfall chat layout

### DIFF
--- a/build-info.json
+++ b/build-info.json
@@ -1,7 +1,7 @@
 {
-  "buildId": "v1.0.0-a480d81",
-  "buildTime": "2025-12-02T11:32:14.799Z",
-  "gitSha": "a480d81faebf7abee1ea73e4b6e687125c9dc54f",
-  "gitBranch": "claude/fix-white-page-ux-013EmkYGA27c4kx7vX4ipxyF",
+  "buildId": "v1.0.0-d6f2601",
+  "buildTime": "2025-12-02T13:48:42.150Z",
+  "gitSha": "d6f2601b7b61593d564309f28639bf8f950ebc75",
+  "gitBranch": "work",
   "version": "1.0.0"
 }

--- a/docs/new-ux-ui-plan.md
+++ b/docs/new-ux-ui-plan.md
@@ -1,0 +1,171 @@
+# Neuer UX/UI-Plan für Disa AI
+
+## 1. Ist-Analyse
+- **Screens laut Router**: Chat, Chat-Historie, Rollen, Modelle, Themen, Feedback, Einstellungen (Übersicht, Memory, Behavior, Jugendschutz, API/Data, Extras, Appearance), Impressum, Datenschutz.
+- **Aktuelles Layout**: Chat-Ansicht mit Page-Swipe/Book-Navigation, Kontext- und Schnellstart-Leisten, History-Sidepanel und Themen-Bottomsheet; diverse Einstellungs-Subpages mit heterogener Kartengestaltung; neumorpher Stil mit starken Schatten.
+- **Design/Styling**: Tailwind + CSS-Variablen über generierte Design-Tokens; dramatischer Neumorphism („erhabene" Karten, starke Schatten), viele Layer-Effekte; Radix-Primitives + CVA-Varianten; Mobile-Gate + Safe-Area-/viewport-Workarounds.
+- **Hauptprobleme**:
+  - Inkonsistente visuelle Linie (wechselnde Karten-/Shadow-Stile, wechselnde Flächenfarben, uneinheitliche Typo-Abstände).
+  - Neumorphismus erschwert Lesbarkeit/Kontrast; zu viele Schatten und Glas-Effekte.
+  - Informationshierarchie unscharf (gleichgewichtete Panels, keine klare Priorität für Chat vs. Nebenfunktionen).
+  - Mobile-Usability leidet unter überfrachteten Toolbars (Kontextbar, Buttons, Sheet, Swipe-Navigation gleichzeitig).
+  - Einstellungen fragmentiert, unterschiedliche Layout-Muster und Buttons.
+  - Icon/Label-Mix uneinheitlich; CTA- und Sekundäraktionen kaum differenziert.
+  - Alte Design-Tokens und CVA-Varianten sind stark verästelt und blockieren einheitliche mobile Patterns.
+
+## 2. Reset / Was wird verworfen
+- **Wird NICHT übernommen**: Neumorphes Karten-/Shadow-Design, „Buchseiten“-Navigation/Swipe-Metapher, heterogene Panel-Rahmen, überladene Kontext-/Statusleisten, flächige Gradients und Glows, inkonsistente Abstands- und Typo-Skalen, parallele Bottomsheet + Sidepanel-Steuerung.
+- **Wird aktiv entfernt**:
+  - Alte Design-Tokens (Farben, Radius, Shadows) und zugehörige Tailwind-Mapping-Dateien.
+  - Verstreute CVA-Varianten für Buttons/Inputs/Cards, die die alte Typo-/Spacing-Skala kodieren.
+  - Book-/Page-Animator-Komponenten, doppelte Layout-Shells, neumorphe CSS-Hilfsdateien.
+  - Historien-Sidepanel-Logik als Pflichtbestandteil des Chats (ersetzt durch dedizierte View/Sheet).
+- **Funktional bleibt, aber neues UI**: Chat-Funktion inkl. Streaming/Stop, Rollen-/Persona-Management, Modellwahl, Themen/Quickstarts, Chat-Historie, Einstellungen (alle Unterseiten), Feedback, Impressum/Datenschutz, Onboarding/Toasts/Fehlerstates.
+
+## 3. Neues UX/UI-Konzept (High-Level)
+- **Design-Identität**: Ruhig, professionell, editorial-tech. Fokus auf klare Flächen, dezente Tiefenstaffelung, hoher Kontrast, präzise Typo, minimaler Farbeinsatz. Keine Glassmorphism-/Neumorph-Ästhetik.
+- **Mobile-First-Gefühl**: Einspaltig, große Touch-Ziele, sticky Kernaktionen (Eingabe unten), reduzierte Navigationsleiste als Bottom-Bar. Gesten nur ergänzend (z.B. Pull-to-refresh, optionaler Swipe für Historie). Safe-Area-Insets berücksichtigen, Scrollbars ausblenden, damit der Content maximalen Platz erhält.
+- **Visuelle Prinzipien**: Content-first, klare Hierarchie, 8pt-Rhythmus, max. zwei Akzentfarben, Schatten nur für Overlays/Modals, flache Karten mit Border statt Glow, konsequente Typo-Skala. Mobile: Priorität auf vertikale Lesbarkeit, kurze Zeilenlängen und konsistente 16px Basisschrift.
+- **Performance/Ergonomie (mobil)**: Animationen ≤150ms, keine schweren Blur-Effekte, zurückhaltende Gradients. Tappable Flächen min. 44x44px, ausreichend vertikale Abstände zwischen Aktionen. Skeleton-Loader statt Spinner, um wahrgenommene Geschwindigkeit zu verbessern.
+- **Design-System-Governance**: Nur ein Token-Set und ein Komponenten-Layer; keine projektspezifischen CSS-Ausreißer. Variantenzahl pro Komponente minimal (Primary, Ghost, Destructive, Text).
+
+## 4. Designsystem (Tokens)
+### Farben (Neutral + Akzent, kein Glow)
+- `--color-bg`: #0B0C10 (Hintergrund dunkel)
+- `--color-surface-1`: #11131A (Grundfläche Karten)
+- `--color-surface-2`: #171A21 (Elevated Surface)
+- `--color-surface-3`: #1D2028 (Modal/Sheet)
+- `--color-primary`: #7CD4FF
+- `--color-primary-strong`: #42B2F5
+- `--color-accent`: #9F7AEA
+- `--color-text-primary`: #F5F7FA
+- `--color-text-secondary`: #C4CBD5
+- `--color-text-tertiary`: #8C94A3
+- `--color-border`: #1F2430
+- `--color-muted`: #1A1E27
+- Status: `--color-success` #4AD295, `--color-warning` #F2C14E, `--color-error` #F06272, `--color-info` #5AB0FF
+
+### Typografie
+- Schrift: "Inter" (Fallback: system-ui). Monospace: "JetBrains Mono" für Code.
+- Hierarchie:
+  - `--font-h1`: 24/32 semi-bold
+  - `--font-h2`: 20/28 semi-bold
+  - `--font-h3`: 18/26 semi-bold
+  - `--font-body`: 16/24 regular
+  - `--font-body-sm`: 14/20 regular
+  - `--font-mono`: 14/20 medium
+
+### Spacing (8pt-Basis)
+- `--space-2`: 4px
+- `--space-3`: 6px
+- `--space-4`: 8px
+- `--space-6`: 12px
+- `--space-8`: 16px
+- `--space-10`: 20px
+- `--space-12`: 24px
+- `--space-16`: 32px
+
+### Radius & Shadow
+- Radius: `--radius-sm` 8px, `--radius-md` 12px, `--radius-lg` 16px, `--radius-pill` 999px.
+- Schatten minimal: `--shadow-sm` 0 6px 20px rgba(0,0,0,0.18); `--shadow-md` 0 12px 28px rgba(0,0,0,0.22). Nur für Modals/Dropdowns.
+
+### States & Tokens-Mapping
+- Hover (Desktop): leichte Hintergrundaufhellung (`surface-2`), Border zu `--color-primary` bei Fokus.
+- Focus: 2px Outline `--color-primary` + 4px Outline Offset transparent.
+- Active/Tap: 98% Scale, Hintergrund zu `--color-muted`.
+- Disabled: 50% Opacity, keine Schatten.
+- Inputs: Border `--color-border`, Fokus Border `--color-primary-strong`, Fehler Border `--color-error`.
+- **Tailwind-Mapping**: Nur ein Token-Set in `src/styles/design-tokens.css`; alte Variablen-Dateien löschen und `tailwind.config` auf neues Set verweisen.
+
+## 5. Screen-Plan & Layout-Wireframes
+### Gemeinsame Bausteine
+- **Topbar** (optional Desktop): Title + sekundäre Aktion (Feedback/Info).
+- **Bottom-Bar Navigation (mobile)**: Chat, Rollen, Modelle, Verlauf, Einstellungen. Fixiert mit Safe-Area-Padding, aktive Sektion klar hervorgehoben, Labels immer sichtbar. Kein zusätzliches Drawer/Split-Layout auf Mobil.
+- **Section Cards**: flache Karten mit Border, Title links, Actions rechts. Tap-Fläche komplett klickbar, Chevron rechts für Navigation, 12–16px vertikales Padding.
+- **Mobile-Optimierung**: Scrollbereiche klar voneinander getrennt, Sticky-Bereiche (Input, Filter-Chips) erhalten Schatten/Border, um Überlagerungen zu vermeiden. Empty-States kompakt mit CTA und kurzer Erklärung.
+
+### Chat (Home)
+- **Ziel**: Hauptinteraktion Chat, schnelle Rollen-/Modellwahl, klarer Eingabefluss.
+- **Inhalt**: Statusbanner (API/Offline), Chatverlauf, Quick Actions (Rolle/Modell/Anhänge), Input mit Send/Stop, optional Kontextchips.
+- **Wireframe**:
+  - HEADER: [Logo/Title] [Statusbadge/Sync]
+  - MAIN: [Chat-History Scroll | Nachrichtenkarten] + [System/Info Banner oben]
+  - FOOTER: [Context chips horizontal] [Input + Send + Stop] (sticky)
+- **Mobile**: Einspaltig, sticky Input mit Safe-Area-Padding, Quick Actions als Icon-Buttons rechts der Inputzeile, Kontextchips horizontal scrollend über dem Input. Letzte Nachricht immer oberhalb der Tastatur sichtbar (Auto-Scroll). Voice/Attachment Buttons optional in Overflow-Menü, um Platz zu sparen.
+- **Tablet/Desktop**: Zwei-Spalten: Chat links (70%), rechts schmale Pane für Rolle/Modell/Verlauf toggelbar.
+
+### Chat-Historie
+- **Ziel**: Gespräche finden/fortsetzen.
+- **Inhalt**: Suche/Filter, Listeneinträge mit Titel, Datum, Tokens/Model, Actions (Fortsetzen, Löschen).
+- **Wireframe**: HEADER [Zurück] [Titel]; LIST [Card: Title | Meta | Actions]; FAB „Neuer Chat“.
+- **Mobile**: Liste einspaltig, Swipe-Aktion Delete/Pin optional, FAB rechts unten mit Safe-Area-Padding. Schnellsuche als Sticky oberhalb der Liste, um sofortigen Zugriff zu bieten. Keine Sidepanel-Variante; Verlauf ist eigener Screen oder Sheet.
+- **Desktop**: Zwei-Spalten (Liste links, Preview rechts optional).
+
+### Rollen/Persona-Manager
+- **Ziel**: Rollen durchstöbern, aktivieren, editieren.
+- **Inhalt**: Kategorien-Filter, Karten mit Avatar/Name/Tags, Favoriten-Toggle, Detail-Sheet, Neu/Bearbeiten-Dialog.
+- **Wireframe**: HEADER [Filter/Sort]; GRID/List Cards; CTA „Neue Rolle“ unten.
+- **Mobile**: 2-Spalten-Grid oder Liste mit kompakten Cards; Details als Bottom Sheet mit Swipe-to-close. Filter-Chips sticky unter dem Header; Favoriten-Toggle gut erreichbar am Card-Rand. Keine eingebetteten Drawer/Sidepanels.
+- **Desktop**: 3-Spalten-Grid, Detailpanel rechts.
+
+### Modelle
+- **Ziel**: Modell auswählen/filtern.
+- **Inhalt**: Suchfeld, Chips (Provider, Preis, Geschwindigkeit), Cards mit Kurzinfos, Favorit/Standard setzen.
+- **Wireframe**: HEADER [Suchfeld]; FILTER Chips; LIST Cards mit Badges (Preis/Speed/Context); Primary CTA „Als Standard setzen“.
+- **Mobile**: Einspaltige Liste, Filter-Chips horizontal scrollend, CTA als Sticky Bottom-Bar („Als Standard setzen“ für ausgewähltes Modell), damit kein Scrollen nötig ist.
+
+### Themen/Quickstarts
+- **Ziel**: Einstiegsthemen anbieten.
+- **Inhalt**: Kategorie-Chips, Cards mit Titel/kurzer Beschreibung, Start-Button.
+- **Wireframe**: Chips horizontal; Cards in Liste; Start führt direkt in Chat und setzt Prompt.
+- **Mobile**: Cards mit prägnanten Titeln und kurzem Text, Start-Button vollflächig pro Card; Kategorie-Chips sticky, um zwischen Themen zu wechseln.
+
+### Einstellungen (Übersicht)
+- **Ziel**: Alle Settings klar gruppiert.
+- **Inhalt**: Abschnitte (Allgemein, Verhalten, Jugendschutz, API & Daten, Extras, Erscheinungsbild), jede als Card mit Kurzbeschreibung + Chevron.
+- **Wireframe**: HEADER [Titel]; SECTION Cards; Fußnote Version/Build.
+- **Mobile**: Einspaltige Liste mit großzügigen Tap-Flächen; primäre Aktionen oben (z.B. Account/Backup), weniger wichtige Links unten. Sticky Topbar mit klarem Titel.
+
+### Einstellungen Detailseiten
+- **Memory/Verhalten/Jugendschutz/API/Extras/Aussehen**: Formfelder mit klaren Labels, Hilfetexten, Toggles/Slider/Select; Primäre CTA „Speichern“, Sekundär „Reset“.
+
+### Feedback
+- **Ziel**: Feedback senden.
+- **Inhalt**: Form (Typ, Nachricht, optional Kontakt), CTA Senden, Erfolgs-/Fehlerhinweis.
+- **Mobile**: Kürzere Form mit Progress-Feedback (CTA wird zu Spinner). Tastatur-Verhalten: Auto-Fokus auf Textfeld, CTA bleibt sichtbar über der Tastatur.
+
+### Impressum/Datenschutz
+- **Ziel**: Rechtstexte lesbar.
+- **Inhalt**: Typo-Hierarchie, Table of Contents Sprunglinks.
+- **Mobile**: TOC als horizontal scrollbare Chips; Abschnittsanker mit sticky Abschnittstiteln für Orientierung.
+
+## 6. Navigation & Informationsarchitektur
+- **Hauptnavigation (mobile)**: Bottom-Bar mit 5 Icons+Labels: Chat, Rollen, Modelle, Verlauf, Einstellungen. Fixiert, mit Safe-Area-Abstand und klarer Aktivmarkierung; kein verstecktes Drawer-Menü nötig.
+- **Sekundärzugriff**: Innerhalb Chat Quick-Links auf Rolle/Modell via kleine Pills über der Eingabe.
+- **Desktop**: Linke Rail (permanent) mit denselben Einträgen; Chat als Start.
+- **Schnelle Aktionen**: Floating „Neuer Chat“ Button auf Chat/Verlauf; Rollenwechsel über Bottom Sheet/Drawer ohne Kontextwechsel. Auf Mobil nur ein Overlay zur Zeit (Sheet oder Modal) für Klarheit.
+- **Reduktion der Komplexität**: Nur eine Overlayschicht gleichzeitig (entweder Sheet oder Drawer), kein gleichzeitiges Sidepanel + Sheet; Navigationspfade auf max. 2 Ebenen begrenzen, Back-Aktion immer sichtbar.
+
+## 7. Interaktionen & Microinteractions
+- Buttons: sanfte 150ms Ease-out, Tap-Scale 0.98, Fokus-Outline klar sichtbar.
+- Inputs: 200ms Border/Fill-Transition; Inline-Validation mit ruhigen Farben.
+- Cards/Listen: Hover-Lift (border-color + leichter Schatten), Tap Ripple dezent auf Mobile.
+- Loader: lineare Progressbar im Header für laufende Requests; Senden-Button zeigt Spinner + „Senden…“.
+- Fehler/Status: Toast unten zentriert; Banner oben für API/Offline; Erfolgs-Checkmarks bei Save.
+- Gesten: Optionaler Swipe nach rechts für Verlauf öffnen (auf Mobil); Pull-to-refresh für Verlaufsliste.
+- Motion: Respektiert `prefers-reduced-motion`; standard 150–200ms Ease, keine Parallax/3D. Mobile-First: Animationen blockieren keine Eingabe, kein starkes Opacity-Fading über dem Keyboard.
+- Mobile-Feedback: Haptisches Feedback (Vibration light) bei langen Aktionen (Senden/Stop), visuelle Ladeindikatoren nahe am Daumen (Input-Bereich).
+
+## 8. Technischer Migrationsplan
+1. **Design-Tokens neu definieren**: `src/styles/design-tokens.css` mit neuer Palette, Typo, Spacing, Radius überschreiben; alte Token-Dateien und Tailwind-Mappings löschen.
+2. **Globale Styles**: `src/index.css` und Basis-Utilities auf neues Farbschema/Rhythmus umstellen; neumorphe Shadows/Gradients und Spezial-Viewport-Hacks entfernen.
+3. **Layout-Shell**: Neues App-Layout mit Bottom-Bar (mobile) und optionaler Side-Rail (desktop) erstellen; `RouteWrapper` vereinfachen und alte Book/Page-Shells streichen.
+4. **Primitives aktualisieren**: Buttons, Inputs, Cards, Chips in `components/ui` an neues Tokensystem binden; CVA-Varianten auf Kernstates reduzieren.
+5. **Chat-Ansicht**: Struktur neu aufbauen (Header+Banner, History, Input-Bar); BookPageAnimator und überflüssige Panels entfernen; Kontextchips/Quick Actions schlank.
+6. **Navigation/Historie**: History-Sidepanel durch dedizierte Seite/Sheet ersetzen; ein Overlay-Typ enforced.
+7. **Rollen/Modelle/Themen**: Einheitliches Card/List-Layout; Filter-Chips standardisieren und alte Drawer/Sidepanels entfernen.
+8. **Einstellungen**: Übersicht + Detailseiten in konsistentes Formular-Layout mit Section Cards; CTA-Pattern vereinheitlichen.
+9. **Feedback/Legal**: Lesbare Typo-Hierarchie, Table of Contents einführen.
+10. **Onboarding/Toasts**: Visuell an neues Schema anpassen; Motion reduzieren.
+11. **Aufräumen**: Alte CSS-Dateien/Komponenten (Neumorphismus, Book-Navigation), doppelte Themes und ungenutzte Assets löschen; Storybook/Docs auf neue Tokens aktualisieren.
+12. **Tests/Docs**: Snapshot/Visual-Tests anpassen, README/Design-Dokumente auf neues System aktualisieren.

--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -2,8 +2,6 @@
 import { type ReactNode, useCallback, useMemo } from "react";
 import { Link, useLocation } from "react-router-dom";
 
-import { BuildInfo } from "../../components/BuildInfo";
-import { AutoBreadcrumbs } from "../../components/navigation/Breadcrumbs";
 import { MobileBackButton } from "../../components/navigation/MobileBackButton";
 import { PrimaryNavigation } from "../../components/navigation/PrimaryNavigation";
 import { isNavItemActive, PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../../config/navigation";
@@ -42,7 +40,7 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
   const isChatMode = location.pathname === "/" || location.pathname.startsWith("/chat");
 
   return (
-    <div className="relative min-h-screen bg-bg-base text-text-primary">
+    <div className="relative min-h-screen bg-bg-app text-text-primary">
       <div className="relative flex min-h-screen flex-col lg:flex-row">
         <a
           href="#main"
@@ -64,28 +62,22 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
           Zum Hauptinhalt springen
         </a>
 
-        <aside className="hidden w-64 flex-shrink-0 border-r border-border-ink/15 bg-bg-page/90 backdrop-blur lg:flex">
+        <aside className="hidden w-64 flex-shrink-0 border-r border-border-ink/20 bg-surface-2 lg:flex">
           <div className="flex h-full w-full flex-col gap-6 px-4 py-5">
             <BrandWordmark className="text-base" />
             <PrimaryNavigation orientation="side" />
-            <div className="mt-auto space-y-2 text-xs text-ink-tertiary">
+            <div className="mt-auto space-y-2 text-xs text-text-tertiary">
               <div className="flex flex-col gap-1">
                 {SECONDARY_NAV_ITEMS.map((item) => (
                   <Link
                     key={item.id}
                     to={item.path}
-                    className="rounded-lg px-3 py-2 transition hover:bg-surface-2"
+                    className="rounded-lg px-3 py-2 transition hover:bg-surface-3"
                   >
                     {item.label}
                   </Link>
                 ))}
               </div>
-              {process.env.NODE_ENV === "development" && (
-                <div className="flex items-center gap-2 rounded-lg border border-border-ink/20 px-3 py-2 text-[11px]">
-                  <span>Build</span>
-                  <BuildInfo />
-                </div>
-              )}
             </div>
           </div>
         </aside>
@@ -97,43 +89,19 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
           {/* Header - Clean for Chat Mode */}
           <header
             className={cn(
-              "sticky top-0 z-header border-b border-border-ink/10 bg-bg-page/90 backdrop-blur",
-              isChatMode && "lg:hidden", // Hide header on desktop in chat mode
+              "sticky top-0 z-header border-b border-border-ink/30 bg-surface-2/95 backdrop-blur",
+              isChatMode && "lg:hidden",
             )}
           >
             <div className="flex items-center gap-3 px-4 py-3 lg:px-6">
               <MobileBackButton />
               <div className="flex items-center gap-2 truncate">
                 <BrandWordmark className="text-sm lg:hidden" />
-                {!isChatMode && (
-                  <span className="text-sm font-semibold text-ink-primary truncate">
-                    {pageTitle}
-                  </span>
-                )}
+                <span className="text-sm font-semibold text-text-primary truncate">
+                  {pageTitle}
+                </span>
               </div>
-              {/* Only show Quickstarts/Feedback on non-chat pages */}
-              {!isChatMode && (
-                <div className="ml-auto flex items-center gap-2">
-                  <Link
-                    to="/themen"
-                    className="rounded-full border border-border-ink/40 px-3 py-1.5 text-xs font-medium text-ink-secondary hover:bg-surface-1"
-                  >
-                    Quickstarts
-                  </Link>
-                  <Link
-                    to="/feedback"
-                    className="rounded-full bg-accent-primary/90 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-accent-primary"
-                  >
-                    Feedback
-                  </Link>
-                </div>
-              )}
             </div>
-            {!isChatMode && (
-              <div className="border-t border-border-ink/10 bg-bg-page/80 px-4 pb-3 pt-2 lg:px-6">
-                <AutoBreadcrumbs className="text-xs" />
-              </div>
-            )}
           </header>
 
           <div
@@ -141,10 +109,7 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
             role="main"
             data-testid="app-main"
             key={location.pathname}
-            className={cn(
-              "relative flex flex-1 flex-col",
-              isChatMode ? "bg-bg-page" : "bg-bg-base",
-            )}
+            className={cn("relative flex flex-1 flex-col", isChatMode ? "bg-bg-page" : "bg-bg-app")}
             tabIndex={-1}
           >
             <div
@@ -162,7 +127,7 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
           </div>
 
           {/* Bottom Navigation - Mobile Only */}
-          <div className="border-t border-border-ink/15 bg-bg-page/95 backdrop-blur lg:hidden">
+          <div className="border-t border-border-ink/30 bg-surface-2/95 backdrop-blur lg:hidden">
             <PrimaryNavigation orientation="bottom" />
           </div>
         </div>

--- a/src/components/navigation/PrimaryNavigation.tsx
+++ b/src/components/navigation/PrimaryNavigation.tsx
@@ -15,7 +15,7 @@ export function PrimaryNavigation({ orientation }: PrimaryNavigationProps) {
       className={cn(
         "w-full",
         orientation === "bottom"
-          ? "flex items-center justify-between gap-1 px-1 pb-2 pt-1"
+          ? "flex items-center justify-between gap-2 px-2 pb-[calc(12px+env(safe-area-inset-bottom,0px))] pt-2"
           : "flex flex-1 flex-col gap-1",
       )}
       aria-label="Hauptnavigation"
@@ -31,10 +31,10 @@ export function PrimaryNavigation({ orientation }: PrimaryNavigationProps) {
             to={item.path}
             className={cn(
               "group flex flex-1 items-center gap-2 rounded-xl text-sm font-medium transition",
-              orientation === "bottom" ? "flex-col px-2 py-2" : "flex-row px-3 py-3",
+              orientation === "bottom" ? "flex-col px-3 py-2" : "flex-row px-3 py-3",
               isActive
-                ? "bg-accent-primary/10 text-accent-primary shadow-[0_6px_16px_-12px_rgba(0,0,0,0.35)]"
-                : "text-ink-secondary hover:bg-surface-2",
+                ? "bg-surface-2 text-text-primary ring-1 ring-accent-primary/40"
+                : "text-text-secondary hover:bg-surface-2 hover:text-text-primary",
             )}
             aria-current={isActive ? "page" : undefined}
           >
@@ -42,9 +42,9 @@ export function PrimaryNavigation({ orientation }: PrimaryNavigationProps) {
               className={cn(
                 "flex items-center justify-center rounded-full border",
                 isActive
-                  ? "border-accent-primary/40 bg-accent-primary/15 text-accent-primary"
-                  : "border-border-ink/30 bg-surface-1 text-ink-secondary",
-                orientation === "bottom" ? "h-8 w-8" : "h-9 w-9",
+                  ? "border-accent-primary/60 bg-accent-primary/15 text-accent-primary"
+                  : "border-border-ink/40 bg-surface-1 text-text-secondary",
+                orientation === "bottom" ? "h-9 w-9" : "h-10 w-10",
               )}
             >
               <Icon className={orientation === "bottom" ? "h-4 w-4" : "h-5 w-5"} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,10 @@
 /**
- * Main CSS Entry Point - Ink on Paper Design System
+ * Main CSS Entry Point - Nightfall Design System
  *
- * Refactored for "Disa AI" Book Concept.
- * Removes Neumorphism/Aurora effects in favor of a calm, flat, physical paper aesthetic.
+ * Mobile-first, high-contrast, calm surfaces with minimal shadows and clear hierarchy.
  */
 
-/* Import Ink Theme FIRST - Source of Truth for Variables */
+/* Import Theme FIRST - Source of Truth for Variables */
 @import "./styles/theme-ink.css";
 
 /* Base Styles & Resets */
@@ -15,7 +14,7 @@
 @import "./styles/vertical-rhythm.css";
 @import "./styles/z-index-system.css";
 
-/* Components - Needs review to ensure they use Ink vars */
+/* Components */
 @import "./styles/components.css";
 
 /* Animations */
@@ -23,10 +22,7 @@
 @import "./styles/ui-state-animations.css";
 /* @import "./styles/logo-animations.css";  -- Keep if subtle, remove if too "loud" */
 
-/* DEPRECATED / REMOVED STYLES for Book Concept:
- * @import "./styles/design-tokens-consolidated.css"; (Neumorphism)
- * @import "./styles/aurora-optimized.css"; (Glow Backgrounds)
- */
+/* Deprecated legacy styles removed as part of the reset */
 
 /* Tailwind CSS */
 @tailwind base;

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { cn } from "@/lib/utils";
 import { useToasts } from "@/ui";
 import { Button } from "@/ui/Button";
 import { ChatStartCard } from "@/ui/ChatStartCard";
@@ -9,16 +8,11 @@ import { ChatStartCard } from "@/ui/ChatStartCard";
 import { ChatInputBar } from "../components/chat/ChatInputBar";
 import { ChatStatusBanner } from "../components/chat/ChatStatusBanner";
 import { ContextBar } from "../components/chat/ContextBar";
-import { ThemenBottomSheet } from "../components/chat/ThemenBottomSheet";
 import { VirtualizedMessageList } from "../components/chat/VirtualizedMessageList";
-import { Bookmark } from "../components/navigation/Bookmark";
-import { BookPageAnimator } from "../components/navigation/BookPageAnimator";
-import { HistorySidePanel } from "../components/navigation/HistorySidePanel";
 import type { ModelEntry } from "../config/models";
 import { QUICKSTARTS } from "../config/quickstarts";
 import { useRoles } from "../contexts/RolesContext";
 import { useConversationStats } from "../hooks/use-storage";
-import { useBookNavigation } from "../hooks/useBookNavigation";
 import { useChat } from "../hooks/useChat";
 import { useConversationManager } from "../hooks/useConversationManager";
 import { useMemory } from "../hooks/useMemory";
@@ -27,7 +21,7 @@ import { buildSystemPrompt } from "../lib/chat/prompt-builder";
 import { MAX_PROMPT_LENGTH, validatePrompt } from "../lib/chat/validation";
 import { mapCreativityToParams } from "../lib/creativity";
 import { humanErrorToToast } from "../lib/errors/humanError";
-import { Plus } from "../lib/icons";
+import { History, Plus } from "../lib/icons";
 import { getSamplingCapabilities } from "../lib/modelCapabilities";
 
 export default function Chat() {
@@ -38,7 +32,6 @@ export default function Chat() {
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [isThemenSheetOpen, setIsThemenSheetOpen] = useState(false);
   const { isEnabled: memoryEnabled } = useMemory();
   const { stats } = useConversationStats();
   const [modelCatalog, setModelCatalog] = useState<ModelEntry[] | null>(null);
@@ -120,55 +113,17 @@ export default function Chat() {
     }
   }, [activeRole, settings.showNSFWContent, setActiveRole, toasts]);
 
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
-
-  const { activeConversationId, selectConversation, newConversation, conversations } =
-    useConversationManager({
-      messages,
-      isLoading,
-      setMessages,
-      setCurrentSystemPrompt,
-      onNewConversation: () => {
-        setInput("");
-      },
-      saveEnabled: memoryEnabled,
-      restoreEnabled: settings.restoreLastConversation && memoryEnabled,
-    });
-
-  const {
-    startNewChat: bookStartNewChat,
-    goBack: bookGoBack,
-    navigateToChat: bookNavigateToChat,
-    updateChatId,
-    swipeStack,
-    activeChatId: bookActiveId,
-  } = useBookNavigation();
-
-  useEffect(() => {
-    if (activeConversationId && bookActiveId && activeConversationId !== bookActiveId) {
-      updateChatId(bookActiveId, activeConversationId);
-    }
-  }, [activeConversationId, bookActiveId, updateChatId]);
-
-  const handleSwipeLeft = useCallback(() => {
-    if (messages.length > 0) {
-      bookStartNewChat();
-      newConversation();
-      toasts.push({ kind: "info", title: "Neue Seite", message: "" });
-    }
-  }, [messages.length, bookStartNewChat, newConversation, toasts]);
-
-  const handleSwipeRight = useCallback(() => {
-    const currentIndex = swipeStack.indexOf(activeConversationId || "");
-    if (currentIndex !== -1 && currentIndex < swipeStack.length - 1) {
-      const prevId = swipeStack[currentIndex + 1];
-      if (prevId) {
-        bookGoBack();
-        void selectConversation(prevId);
-        toasts.push({ kind: "info", title: "Zurückgeblättert", message: "" });
-      }
-    }
-  }, [swipeStack, activeConversationId, bookGoBack, selectConversation, toasts]);
+  const { activeConversationId, newConversation, conversations } = useConversationManager({
+    messages,
+    isLoading,
+    setMessages,
+    setCurrentSystemPrompt,
+    onNewConversation: () => {
+      setInput("");
+    },
+    saveEnabled: memoryEnabled,
+    restoreEnabled: settings.restoreLastConversation && memoryEnabled,
+  });
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -271,187 +226,153 @@ export default function Chat() {
     }
   }, [searchParams, navigate, startWithPreset]);
 
-  const isEmpty = messages.length === 0;
   const activeConversation = conversations?.find((c) => c.id === activeConversationId);
-  const showFab = !isEmpty;
+  const conversationCount = conversations?.length ?? 0;
+
+  const handleStartNewChat = useCallback(() => {
+    newConversation();
+    setInput("");
+  }, [newConversation, setInput]);
+
+  const handleOpenHistory = useCallback(() => {
+    void navigate("/chat/history");
+  }, [navigate]);
+
+  const isEmpty = messages.length === 0;
 
   return (
-    <div className="relative flex flex-col text-ink-primary h-full min-h-[calc(var(--vh,1vh)*100)] bg-bg-app">
+    <div className="relative flex min-h-[calc(var(--vh,1vh)*100)] flex-col bg-bg-page text-text-primary">
       <h1 className="sr-only">Disa AI – Chat</h1>
 
-      {/* Mobile FAB - New Page Button */}
-      {showFab && (
-        <Button
-          variant="secondary"
-          size="icon"
-          onClick={handleSwipeLeft}
-          className="fixed z-fab flex items-center justify-center w-11 h-11 bg-ink-primary hover:bg-ink-primary/90 text-white rounded-full shadow-lg sm:hidden opacity-90 hover:opacity-100 transition-all touch-manipulation"
-          style={{
-            top: `calc(3.5rem + env(safe-area-inset-top, 0px))`,
-            right: `max(1rem, env(safe-area-inset-right, 0px))`,
-          }}
-          aria-label="Neuen Chat starten"
-        >
-          <span className="sr-only">Neuer Chat</span>
-          <Plus className="w-5 h-5" />
-        </Button>
-      )}
-
-      <BookPageAnimator
-        activeChatId={activeConversationId}
-        swipeStack={swipeStack}
-        onSwipeLeft={handleSwipeLeft}
-        onSwipeRight={handleSwipeRight}
-        canSwipeLeft={messages.length > 0}
-        canSwipeRight={
-          swipeStack.length > 1 &&
-          swipeStack.indexOf(activeConversationId || "") < swipeStack.length - 1
-        }
-      >
-        {/* Container matches BookPageAnimator expectations */}
-        <div className="relative flex flex-col text-ink-primary h-full min-h-0 bg-bg-page">
-          {/* Bookmark positioned relative to this container */}
-          <Bookmark
-            onClick={() => setIsHistoryOpen(true)}
-            className="absolute top-0 right-3 sm:right-4"
-            disabled={(conversations || []).length === 0}
-          />
-
-          {/* Simplified Header */}
-          <div className="px-3 sm:px-4 pt-4 pb-2 flex items-center gap-2">
-            <div className="min-w-0 flex-1">
-              <div className="text-[11px] uppercase tracking-[0.08em] text-ink-tertiary">
-                Aktuelle Seite
-              </div>
-              <div className="text-lg font-semibold text-ink-primary truncate">
-                {activeConversation?.title || "Neue Unterhaltung"}
-              </div>
-            </div>
+      <div className="border-b border-border-ink/40 bg-surface-2 px-4 py-3 sm:px-6">
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+              Aktive Unterhaltung
+            </p>
+            <p className="text-lg font-semibold text-text-primary truncate">
+              {activeConversation?.title || "Neue Unterhaltung"}
+            </p>
           </div>
-
-          <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
-
-          {/* Chat Messages Area - Scrollable */}
-          <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden relative flex flex-col">
-            {isEmpty ? (
-              <div className="flex-1 flex items-center justify-center px-4 py-8">
-                <ChatStartCard
-                  onNewChat={() => setIsHistoryOpen(true)}
-                  conversationCount={stats?.totalConversations || 0}
-                />
-              </div>
-            ) : (
-              /* Chat messages with visible "page" container */
-              <div
-                className={cn(
-                  "flex-1 mx-2 sm:mx-4 my-2 rounded-xl",
-                  "bg-bg-page border border-border-ink/20",
-                  "shadow-sm",
-                  // Stack effect: subtle pages behind
-                  "relative before:absolute before:inset-x-1 before:-bottom-1 before:h-2 before:bg-bg-page/60 before:rounded-b-lg before:-z-10",
-                )}
-                data-testid="chat-message-list"
-              >
-                <VirtualizedMessageList
-                  messages={messages}
-                  isLoading={isLoading}
-                  onCopy={(content) => {
-                    navigator.clipboard.writeText(content).catch((err) => {
-                      console.error("Failed to copy content:", err);
-                    });
-                  }}
-                  onEdit={handleEdit}
-                  onFollowUp={handleFollowUp}
-                  onRetry={(messageId) => {
-                    const messageIndex = messages.findIndex((m) => m.id === messageId);
-                    if (messageIndex === -1) return;
-
-                    const targetUserIndex = (() => {
-                      const targetMsg = messages[messageIndex];
-                      if (targetMsg && targetMsg.role === "user") return messageIndex;
-                      for (let i = messageIndex; i >= 0; i -= 1) {
-                        const candidate = messages[i];
-                        if (candidate && candidate.role === "user") return i;
-                      }
-                      return -1;
-                    })();
-
-                    if (targetUserIndex === -1) {
-                      toasts.push({
-                        kind: "warning",
-                        title: "Retry nicht möglich",
-                        message: "Keine passende Nutzernachricht gefunden.",
-                      });
-                      return;
-                    }
-
-                    const userMessage = messages[targetUserIndex];
-                    if (!userMessage) return;
-                    const historyContext = messages.slice(0, targetUserIndex);
-                    setMessages(historyContext);
-                    void append({ role: "user", content: userMessage.content }, historyContext);
-                  }}
-                  className="h-full"
-                />
-              </div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-
-          {/* Input Area - Fixed at bottom */}
-          <div className="bg-bg-page z-composer border-t border-border-ink/30 shadow-[0_-4px_16px_-4px_rgba(0,0,0,0.06)]">
-            <div className="max-w-3xl mx-auto">
-              {/* Chat Input */}
-              <div className="px-2 pt-1.5 sm:px-4 sm:pt-2">
-                <ChatInputBar
-                  value={input}
-                  onChange={setInput}
-                  onSend={handleSend}
-                  isLoading={isLoading}
-                  onQuickAction={(prompt) => setInput(prompt)}
-                />
-              </div>
-
-              {/* Context Bar: AI Behavior Controls */}
-              <ContextBar
-                modelCatalog={modelCatalog}
-                onSend={handleSend}
-                onStop={stop}
-                isLoading={isLoading}
-                canSend={!!input.trim()}
-                className="border-t border-border-ink/20 mt-2"
-              />
-            </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Verlauf öffnen"
+              onClick={handleOpenHistory}
+              className="hidden sm:inline-flex"
+            >
+              <History className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="icon"
+              aria-label="Verlauf öffnen"
+              onClick={handleOpenHistory}
+              className="sm:hidden"
+            >
+              <History className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="primary"
+              size="default"
+              onClick={handleStartNewChat}
+              className="hidden sm:inline-flex"
+            >
+              <Plus className="h-4 w-4" />
+              <span className="ml-2">Neuer Chat</span>
+            </Button>
+            <Button
+              variant="primary"
+              size="icon"
+              onClick={handleStartNewChat}
+              className="sm:hidden"
+              aria-label="Neuer Chat"
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
           </div>
         </div>
+      </div>
 
-        <ThemenBottomSheet
-          isOpen={isThemenSheetOpen}
-          onClose={() => setIsThemenSheetOpen(false)}
-          onStart={startWithPreset}
-        />
-      </BookPageAnimator>
+      <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
 
-      <HistorySidePanel
-        isOpen={isHistoryOpen}
-        onClose={() => setIsHistoryOpen(false)}
-        activePages={swipeStack.map((id) => {
-          const conv = (conversations || []).find((c) => c.id === id);
-          return { id, title: conv?.title || "Unbenannte Seite" };
-        })}
-        archivedPages={(conversations || [])
-          .filter((c) => !swipeStack.includes(c.id))
-          .map((c) => ({
-            id: c.id,
-            title: c.title,
-            date: new Date(c.updatedAt).toLocaleDateString(),
-          }))}
-        activeChatId={activeConversationId}
-        onSelectChat={(id) => {
-          void selectConversation(id);
-          bookNavigateToChat(id);
-        }}
-      />
+      <div className="flex flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto px-3 py-3 sm:px-6 sm:py-4">
+          {isEmpty ? (
+            <ChatStartCard
+              onNewChat={handleStartNewChat}
+              conversationCount={stats?.totalConversations ?? conversationCount}
+            />
+          ) : (
+            <div className="relative flex min-h-[320px] flex-col overflow-hidden rounded-xl border border-border-ink/40 bg-surface-2 shadow-sm">
+              <VirtualizedMessageList
+                messages={messages}
+                isLoading={isLoading}
+                onCopy={(content) => {
+                  navigator.clipboard.writeText(content).catch((err) => {
+                    console.error("Failed to copy content:", err);
+                  });
+                }}
+                onEdit={handleEdit}
+                onFollowUp={handleFollowUp}
+                onRetry={(messageId) => {
+                  const messageIndex = messages.findIndex((m) => m.id === messageId);
+                  if (messageIndex === -1) return;
+
+                  const targetUserIndex = (() => {
+                    const targetMsg = messages[messageIndex];
+                    if (targetMsg && targetMsg.role === "user") return messageIndex;
+                    for (let i = messageIndex; i >= 0; i -= 1) {
+                      const candidate = messages[i];
+                      if (candidate && candidate.role === "user") return i;
+                    }
+                    return -1;
+                  })();
+
+                  if (targetUserIndex === -1) {
+                    toasts.push({
+                      kind: "warning",
+                      title: "Retry nicht möglich",
+                      message: "Keine passende Nutzernachricht gefunden.",
+                    });
+                    return;
+                  }
+
+                  const userMessage = messages[targetUserIndex];
+                  if (!userMessage) return;
+                  const historyContext = messages.slice(0, targetUserIndex);
+                  setMessages(historyContext);
+                  void append({ role: "user", content: userMessage.content }, historyContext);
+                }}
+                className="h-full"
+              />
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <div className="border-t border-border-ink/40 bg-surface-2/95 px-3 py-3 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md sm:px-6 sm:py-4">
+          <div className="mx-auto w-full max-w-4xl space-y-3">
+            <ChatInputBar
+              value={input}
+              onChange={setInput}
+              onSend={handleSend}
+              isLoading={isLoading}
+              onQuickAction={(prompt) => setInput(prompt)}
+            />
+
+            <ContextBar
+              modelCatalog={modelCatalog}
+              onSend={handleSend}
+              onStop={stop}
+              isLoading={isLoading}
+              canSend={!!input.trim()}
+              className="border-t border-border-ink/30 pt-3"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/styles/design-tokens.generated.ts
+++ b/src/styles/design-tokens.generated.ts
@@ -247,5 +247,5 @@ export const preCalculatedTokens: Record<"light" | "dark", CssVariableMap> = {
 } as const;
 
 // Performance: Pre-calculated tokens eliminate ~4ms runtime calculation per theme switch
-// Generated: 2025-12-02T11:32:15.754Z
+// Generated: 2025-12-02T13:48:44.855Z
 // Tokens: 117 variables per theme

--- a/src/styles/theme-ink.css
+++ b/src/styles/theme-ink.css
@@ -1,140 +1,98 @@
 /**
- * DISA AI - INK ON PAPER THEME
- *
- * Concept: "Tinte auf Papier" - Calm book aesthetic
- *
- * Colors:
- * - Off-white paper backgrounds
- * - Dark ink text
- * - Muted indigo accents
+ * Disa AI – Nightfall Design Tokens
+ * Mobile-first, high-contrast, calm surfaces without neumorph shadows.
+ * Single source of truth for Tailwind mappings and component variables.
  */
 
 :root {
-  /* ========================================
-   * COLOR PALETTE
-   * ======================================== */
+  /* ==============================
+   * CORE COLORS
+   * ============================== */
+  --color-bg: #0b0c10;
+  --color-surface-1: #11131a;
+  --color-surface-2: #171a21;
+  --color-surface-3: #1d2028;
+  --color-primary: #7cd4ff;
+  --color-primary-strong: #42b2f5;
+  --color-accent: #9f7aea;
+  --color-text-primary: #f5f7fa;
+  --color-text-secondary: #c4cbd5;
+  --color-text-tertiary: #8c94a3;
+  --color-border: #1f2430;
+  --color-muted: #1a1e27;
 
-  /* Paper Backgrounds */
-  --bg-app: hsl(45, 25%, 96%); /* App background - Warm off-white */
-  --bg-page: hsl(45, 20%, 98%); /* Page/Chat background - Slightly lighter */
-  --bg-surface: hsl(45, 20%, 98%); /* For cards/surfaces */
+  --color-success: #4ad295;
+  --color-warning: #f2c14e;
+  --color-error: #f06272;
+  --color-info: #5ab0ff;
 
-  /* Ink Colors */
-  --ink-primary: hsl(220, 15%, 18%); /* Dark Blue-Black */
-  --ink-secondary: hsl(220, 10%, 50%); /* Muted Grey */
-  --ink-tertiary: hsl(220, 10%, 55%); /* Light Grey - Timestamps, Hints (boosted contrast) */
-  --ink-on-accent: hsl(45, 20%, 98%); /* Light text on accent */
+  /* ==============================
+   * ALIASES FOR EXISTING UTILITIES
+   * ============================== */
+  --bg-app: var(--color-bg);
+  --bg-page: var(--color-surface-1);
+  --bg-surface: var(--color-surface-2);
+  --bg-base: var(--color-bg);
+  --bg-0: var(--color-bg);
+  --bg-1: var(--color-surface-1);
+  --bg-2: var(--color-surface-2);
 
-  /* Accent Colors */
-  --accent-primary: hsl(260, 35%, 45%); /* Muted Indigo/Violet */
-  --accent-secondary: hsl(260, 25%, 65%); /* Lighter Violet */
-  --accent-hover: hsl(260, 40%, 40%);
+  --surface-1: var(--color-surface-1);
+  --surface-2: var(--color-surface-2);
+  --surface-3: var(--color-surface-3);
+  --surface-inset: var(--color-muted);
 
-  /* Semantic Colors */
-  --color-success: hsl(140, 40%, 45%);
-  --color-warning: hsl(35, 80%, 50%);
-  --color-error: hsl(0, 60%, 45%);
+  --ink-primary: var(--color-text-primary);
+  --ink-secondary: var(--color-text-secondary);
+  --ink-tertiary: var(--color-text-tertiary);
+  --ink-on-accent: var(--color-surface-1);
 
-  /* Mapping to existing variable names for compatibility */
-  --bg-base: var(--bg-app);
-  --bg-0: var(--bg-app);
-  --bg-1: var(--bg-page);
-  --bg-2: var(--bg-page);
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --text-muted: var(--color-text-tertiary);
+  --text-disabled: color-mix(in srgb, var(--color-text-tertiary) 65%, transparent);
+  --text-on-accent: var(--color-surface-1);
 
-  --surface-1: var(--bg-page);
-  --surface-2: var(--bg-page); /* No elevation distinction by color, use shadow */
-  --surface-3: hsl(45, 15%, 92%); /* Hover state */
-  --surface-inset: hsl(45, 10%, 94%);
+  --accent: var(--color-primary);
+  --accent-primary: var(--color-primary);
+  --accent-secondary: var(--color-accent);
+  --accent-hover: var(--color-primary-strong);
+  --brand: var(--color-primary);
 
-  --text-primary: var(--ink-primary);
-  --text-secondary: var(--ink-secondary);
-  --text-muted: var(--ink-secondary);
-  --text-disabled: hsl(220, 10%, 65%);
-  --text-on-accent: var(--ink-on-accent);
+  /* ==============================
+   * BORDERS & SHADOWS
+   * ============================== */
+  --border-color: var(--color-border);
+  --border-ink: var(--color-border);
+  --border-width: 1px;
 
-  --accent: var(--accent-primary);
-  --brand: var(--accent-primary);
-
-  /* ========================================
-   * SHADOWS & BORDERS
-   * ======================================== */
-
-  /* Subtle Paper Shadows */
-  --shadow-paper: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-floating: 0 4px 12px rgba(0, 0, 0, 0.12);
-
-  /* Map to existing names */
+  --shadow-paper: 0 6px 20px rgba(0, 0, 0, 0.18);
+  --shadow-floating: 0 12px 28px rgba(0, 0, 0, 0.22);
   --shadow-sm: var(--shadow-paper);
   --shadow-md: var(--shadow-floating);
   --shadow-soft-raise: var(--shadow-paper);
   --shadow-strong-raise: var(--shadow-floating);
-  --shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.06);
-
-  /* Legacy mappings for component compatibility */
+  --shadow-inset: inset 0 1px 3px rgba(0, 0, 0, 0.25);
   --shadow-raise: var(--shadow-paper);
   --shadow-raiseLg: var(--shadow-floating);
+  --shadow-brandGlow: none;
+  --shadow-brandGlowLg: none;
+  --shadow-accentGlow: none;
+  --shadow-accentGlowLg: none;
 
-  /* Glow effects for brand and accent colors */
-  --shadow-brandGlow: 0 0 20px hsla(260, 35%, 45%, 0.25);
-  --shadow-brandGlowLg: 0 0 32px hsla(260, 35%, 45%, 0.3);
-  --shadow-accentGlow: 0 0 20px hsla(260, 35%, 45%, 0.25);
-  --shadow-accentGlowLg: 0 0 32px hsla(260, 35%, 45%, 0.3);
-
-  /* Borders */
-  --border-color: hsl(45, 10%, 90%);
-  --border-ink: hsl(45, 10%, 90%); /* Alias for border-color for consistency */
-  --border-width: 1px;
-
-  /* Radius */
+  /* ==============================
+   * RADII & TYPOGRAPHY
+   * ============================== */
   --r-sm: 8px;
   --r-md: 12px;
   --r-lg: 16px;
+  --r-pill: 999px;
 
-  /* ========================================
-   * TYPOGRAPHY
-   * ======================================== */
-
-  --font-sans: system-ui, -apple-system, sans-serif; /* Clean Sans */
-
-  --text-base: 17px; /* Mobile legible */
-  --leading-normal: 1.6;
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --text-base: 16px;
+  --leading-normal: 1.5;
 }
 
-/* Dark Mode Overrides - Applied when user selects dark theme */
 :root[data-theme="dark"] {
-  --bg-app: hsl(220, 15%, 10%);
-  --bg-page: hsl(220, 15%, 14%);
-  --bg-surface: hsl(220, 15%, 16%);
-
-  --ink-primary: hsl(45, 10%, 90%);
-  --ink-secondary: hsl(220, 10%, 70%);
-  --ink-tertiary: hsl(220, 10%, 60%);
-
-  --accent-primary: hsl(260, 40%, 60%);
-  --accent-secondary: hsl(260, 30%, 70%);
-  --accent-hover: hsl(260, 45%, 65%);
-
-  --border-color: hsl(220, 10%, 25%);
-  --border-ink: hsl(220, 10%, 25%); /* Dark mode border */
-
-  --shadow-paper: 0 1px 3px rgba(0, 0, 0, 0.3);
-  --shadow-floating: 0 4px 12px rgba(0, 0, 0, 0.4);
-
-  /* Dark mode glow effects */
-  --shadow-brandGlow: 0 0 20px hsla(260, 40%, 60%, 0.4);
-  --shadow-brandGlowLg: 0 0 32px hsla(260, 40%, 60%, 0.5);
-  --shadow-accentGlow: 0 0 20px hsla(260, 40%, 60%, 0.4);
-  --shadow-accentGlowLg: 0 0 32px hsla(260, 40%, 60%, 0.5);
-
-  /* Update surface mappings for dark mode */
-  --surface-1: hsl(220, 15%, 14%);
-  --surface-2: hsl(220, 15%, 16%);
-  --surface-3: hsl(220, 15%, 20%);
-  --surface-inset: hsl(220, 15%, 12%);
-
-  /* Update text mappings for dark mode */
-  --text-primary: hsl(45, 10%, 90%);
-  --text-secondary: hsl(220, 10%, 70%);
-  --text-muted: hsl(220, 10%, 60%);
-  --text-disabled: hsl(220, 10%, 45%);
+  color-scheme: dark;
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -10,15 +10,15 @@ import { cn } from "@/lib/utils";
  * Focuses on clarity, touch targets (min 44px), and subtle paper interactions.
  */
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-primary disabled:opacity-50 disabled:pointer-events-none cursor-pointer",
+  "inline-flex items-center justify-center rounded-md text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/70 disabled:opacity-50 disabled:pointer-events-none cursor-pointer",
   {
     variants: {
       variant: {
         primary:
-          "bg-accent text-white shadow-sm hover:shadow-md hover:bg-accent-hover active:translate-y-[1px]",
+          "bg-accent-primary text-surface-1 shadow-sm hover:bg-accent-hover active:translate-y-[1px]",
         secondary:
-          "bg-bg-page text-ink-primary border border-border-ink shadow-sm hover:bg-bg-surface hover:shadow-md active:translate-y-[1px]",
-        ghost: "hover:bg-bg-surface text-ink-primary hover:text-accent active:bg-bg-surface/80",
+          "bg-surface-2 text-text-primary border border-border-ink shadow-sm hover:bg-surface-3 hover:shadow-md active:translate-y-[1px]",
+        ghost: "hover:bg-surface-2 text-text-secondary hover:text-text-primary active:bg-surface-3",
         link: "text-accent underline-offset-4 hover:underline p-0 h-auto min-h-0",
       },
       size: {

--- a/src/ui/ChatStartCard.tsx
+++ b/src/ui/ChatStartCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
 import { BrandWordmark } from "../app/components/BrandWordmark";
-import { Book, History, Sparkles } from "../lib/icons";
+import { History, Sparkles } from "../lib/icons";
 import { buttonVariants } from "./Button";
 
 /**
@@ -18,30 +18,25 @@ interface ChatStartCardProps {
 
 export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCardProps) {
   return (
-    <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
-      {/* Buch-Icon */}
-      <div className="w-16 h-16 rounded-2xl bg-surface-1 border border-border-ink/20 flex items-center justify-center mb-6 shadow-sm">
-        <Book className="w-8 h-8 text-accent-primary" />
+    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-border-ink/30 bg-surface-2 px-6 py-8 text-center shadow-sm">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-accent-primary/10 text-accent-primary">
+        <Sparkles className="h-6 w-6" />
       </div>
 
-      {/* Branding */}
-      <BrandWordmark className="text-2xl sm:text-3xl mb-3" state="idle" />
+      <BrandWordmark className="text-2xl sm:text-3xl" state="idle" />
 
-      {/* Tagline */}
-      <p className="text-sm text-ink-secondary max-w-xs mx-auto leading-relaxed mb-8">
-        Dein digitales Notizbuch für Gespräche.
-        <br />
-        <span className="text-ink-tertiary">Schreibe los – diese Seite wartet auf dich.</span>
+      <p className="max-w-xl text-sm leading-relaxed text-text-secondary">
+        Starte ein neues Gespräch oder setze eine Unterhaltung fort. Schlanke Eingabeleiste, klare
+        Kontraste und fokussierte Aktionen sorgen für Ruhe im Flow.
       </p>
 
-      {/* Actions */}
-      <div className="flex flex-col sm:flex-row gap-3 w-full max-w-xs">
+      <div className="flex w-full max-w-md flex-col gap-3 sm:flex-row">
         <button
           onClick={onNewChat}
-          className="flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-ink-primary text-surface-1 font-medium text-sm hover:bg-ink-primary/90 active:scale-[0.98] transition-all shadow-sm w-full"
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60"
         >
           <Sparkles className="h-4 w-4" />
-          Beginne zu schreiben
+          Neues Gespräch
         </button>
 
         {conversationCount > 0 && (
@@ -50,7 +45,8 @@ export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCar
             className={buttonVariants({
               variant: "secondary",
               size: "default",
-              className: "flex items-center justify-center gap-2 w-full border-border-ink/30",
+              className:
+                "flex w-full items-center justify-center gap-2 border-border-ink/40 bg-surface-1 text-text-primary",
             })}
           >
             <History className="h-4 w-4" />

--- a/src/ui/__tests__/Button.test.tsx
+++ b/src/ui/__tests__/Button.test.tsx
@@ -13,14 +13,14 @@ describe("Button", () => {
   it("applies primary variant classes", () => {
     render(<Button variant="primary">Primary</Button>);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("bg-accent");
-    expect(button.className).toContain("text-white");
+    expect(button.className).toContain("bg-accent-primary");
+    expect(button.className).toContain("text-surface-1");
   });
 
   it("applies secondary variant classes", () => {
     render(<Button variant="secondary">Secondary</Button>);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("bg-bg-page");
+    expect(button.className).toContain("bg-surface-2");
     expect(button.className).toContain("border-border-ink");
   });
 });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -89,15 +89,15 @@ const colorTokens = {
 const spacingScale = {
   0: "0px",
   1: "4px",
-  2: "8px",
-  3: "12px",
-  4: "16px",
-  5: "20px",
-  6: "24px",
-  7: "32px",
-  8: "40px",
-  9: "48px",
-  10: "64px",
+  2: "6px",
+  3: "8px",
+  4: "12px",
+  5: "16px",
+  6: "20px",
+  7: "24px",
+  8: "32px",
+  9: "40px",
+  10: "48px",
 };
 
 const radii = {


### PR DESCRIPTION
## Summary
- replace the legacy ink theme with the new Nightfall tokens, spacing scale, and navigation styling
- rebuild the chat shell and start experience around a bottom-first mobile layout with simplified controls
- align buttons and tests with the updated design system variants

## Testing
- npm run verify
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ee1a978088320b8b5348153402879)