### PR TITLE
feat: replace mobile nav with hamburger drawer

### DIFF
--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -2,11 +2,40 @@
 import { type ReactNode, useCallback, useMemo } from "react";
 import { Link, useLocation } from "react-router-dom";
 
+import { AppMenuDrawer, MenuIcon, useMenuDrawer } from "../../components/layout/AppMenuDrawer";
 import { MobileBackButton } from "../../components/navigation/MobileBackButton";
 import { PrimaryNavigation } from "../../components/navigation/PrimaryNavigation";
 import { isNavItemActive, PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../../config/navigation";
+import { Brain, Cpu, Info, MessageSquare, Settings, Users } from "../../lib/icons";
 import { cn } from "../../lib/utils";
 import { BrandWordmark } from "../components/BrandWordmark";
+
+const HAMBURGER_NAV_ITEMS = [
+  { id: "models", label: "Models", path: "/models", Icon: Cpu, activePattern: /^\/models/ },
+  { id: "roles", label: "Rollen", path: "/roles", Icon: Users, activePattern: /^\/roles/ },
+  {
+    id: "settings",
+    label: "Einstellungen",
+    path: "/settings",
+    Icon: Settings,
+    activePattern: /^\/settings/,
+  },
+  {
+    id: "quickstarts",
+    label: "Quickstarts",
+    path: "/themen",
+    Icon: Brain,
+    activePattern: /^\/themen/,
+  },
+  {
+    id: "feedback",
+    label: "Feedback",
+    path: "/feedback",
+    Icon: MessageSquare,
+    activePattern: /^\/feedback/,
+  },
+  { id: "about", label: "Über", path: "/impressum", Icon: Info, activePattern: /^\/impressum/ },
+] satisfies typeof PRIMARY_NAV_ITEMS;
 
 interface AppShellProps {
   children: ReactNode;
@@ -23,6 +52,7 @@ export function AppShell({ children }: AppShellProps) {
 }
 
 function AppShellLayout({ children, location }: AppShellLayoutProps) {
+  const menuDrawer = useMenuDrawer();
   const focusMain = useCallback(() => {
     const mainEl = document.getElementById("main");
     if (!mainEl) return;
@@ -94,13 +124,16 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
             )}
           >
             <div className="flex items-center gap-3 px-4 py-3 lg:px-6">
-              <MobileBackButton />
-              <div className="flex items-center gap-2 truncate">
-                <BrandWordmark className="text-sm lg:hidden" />
-                <span className="text-sm font-semibold text-text-primary truncate">
-                  {pageTitle}
-                </span>
+              <div className="flex flex-1 items-center gap-3 truncate">
+                <MobileBackButton />
+                <div className="flex items-center gap-2 truncate">
+                  <BrandWordmark className="text-sm lg:hidden" />
+                  <span className="text-sm font-semibold text-text-primary truncate">
+                    {pageTitle}
+                  </span>
+                </div>
               </div>
+              <MenuIcon onClick={menuDrawer.openMenu} className="ml-auto" />
             </div>
           </header>
 
@@ -126,10 +159,12 @@ function AppShellLayout({ children, location }: AppShellLayoutProps) {
             </div>
           </div>
 
-          {/* Bottom Navigation - Mobile Only */}
-          <div className="border-t border-border-ink/30 bg-surface-2/95 backdrop-blur lg:hidden">
-            <PrimaryNavigation orientation="bottom" />
-          </div>
+          <AppMenuDrawer
+            isOpen={menuDrawer.isOpen}
+            onClose={menuDrawer.closeMenu}
+            navItems={HAMBURGER_NAV_ITEMS}
+            secondaryItems={[]}
+          />
         </div>
       </div>
     </div>

--- a/src/components/layout/AppMenuDrawer.tsx
+++ b/src/components/layout/AppMenuDrawer.tsx
@@ -6,6 +6,7 @@ import { Link, useLocation } from "react-router-dom";
 import { MaterialCard } from "@/ui/MaterialCard";
 
 import { BrandWordmark } from "../../app/components/BrandWordmark";
+import type { AppNavItem } from "../../config/navigation";
 import { isNavItemActive, PRIMARY_NAV_ITEMS } from "../../config/navigation";
 import { X } from "../../lib/icons";
 import { cn } from "../../lib/utils";
@@ -14,9 +15,17 @@ interface AppMenuDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   className?: string;
+  navItems?: AppNavItem[];
+  secondaryItems?: AppNavItem[];
 }
 
-export function AppMenuDrawer({ isOpen, onClose, className }: AppMenuDrawerProps) {
+export function AppMenuDrawer({
+  isOpen,
+  onClose,
+  className,
+  navItems,
+  secondaryItems,
+}: AppMenuDrawerProps) {
   const location = useLocation();
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -68,10 +77,12 @@ export function AppMenuDrawer({ isOpen, onClose, className }: AppMenuDrawerProps
   };
 
   // Sekundäre Seiten
-  const secondaryPages = [
-    { label: "Impressum", href: "/impressum" },
-    { label: "Datenschutz", href: "/datenschutz" },
+  const secondaryPages: AppNavItem[] = secondaryItems ?? [
+    { id: "impressum", label: "Impressum", path: "/impressum", Icon: X },
+    { id: "datenschutz", label: "Datenschutz", path: "/datenschutz", Icon: X },
   ];
+
+  const navigationItems = navItems ?? PRIMARY_NAV_ITEMS;
 
   // Lock background scroll while the drawer is open
   useEffect(() => {
@@ -150,7 +161,7 @@ export function AppMenuDrawer({ isOpen, onClose, className }: AppMenuDrawerProps
           {/* Navigation Section */}
           <nav className="px-4 py-4">
             <ul className="space-y-1" role="list">
-              {PRIMARY_NAV_ITEMS.map((item) => {
+              {navigationItems.map((item) => {
                 const isActive = isNavItemActive(item, location.pathname);
                 const Icon = item.Icon;
 
@@ -186,28 +197,32 @@ export function AppMenuDrawer({ isOpen, onClose, className }: AppMenuDrawerProps
               })}
             </ul>
 
-            {/* Divider */}
-            <hr className="my-4 border-border-ink/10" />
+            {secondaryPages.length > 0 && (
+              <>
+                {/* Divider */}
+                <hr className="my-4 border-border-ink/10" />
 
-            {/* Secondary Links */}
-            <ul className="space-y-1" role="list">
-              {secondaryPages.map((page) => (
-                <li key={page.href}>
-                  <Link
-                    to={page.href}
-                    onClick={onClose}
-                    className={cn(
-                      "flex items-center px-3 py-2.5 rounded-lg transition-colors text-sm min-h-[44px]",
-                      location.pathname === page.href
-                        ? "text-accent-primary bg-accent-primary/5"
-                        : "text-ink-secondary hover:text-ink-primary hover:bg-surface-2",
-                    )}
-                  >
-                    {page.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+                {/* Secondary Links */}
+                <ul className="space-y-1" role="list">
+                  {secondaryPages.map((page) => (
+                    <li key={page.id}>
+                      <Link
+                        to={page.path}
+                        onClick={onClose}
+                        className={cn(
+                          "flex items-center px-3 py-2.5 rounded-lg transition-colors text-sm min-h-[44px]",
+                          location.pathname === page.path
+                            ? "text-accent-primary bg-accent-primary/5"
+                            : "text-ink-secondary hover:text-ink-primary hover:bg-surface-2",
+                        )}
+                      >
+                        {page.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
           </nav>
 
           {/* Footer */}


### PR DESCRIPTION
## Summary
- replace the mobile bottom navigation with a header hamburger trigger that opens a slide-in menu
- route the hamburger menu to key destinations and retire redundant mobile navigation surfaces
- generalize AppMenuDrawer to accept custom navigation lists and optional secondary links

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0dad0b0c8320842e77fa8df67971)