### PR TITLE
Refactor conversation history handling in Chat

### DIFF
--- a/src/hooks/useConversationHistory.ts
+++ b/src/hooks/useConversationHistory.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import type { Conversation } from "../lib/conversation-manager-modern";
+
+interface HistoryPage {
+  id: string;
+  title: string;
+  date: string;
+}
+
+interface ConversationHistory {
+  conversationList: Conversation[];
+  conversationCount: number;
+  activeConversation: Conversation | null;
+  historyPages: HistoryPage[];
+  activeHistoryPages: HistoryPage[];
+  archivedHistoryPages: HistoryPage[];
+}
+
+export function useConversationHistory(
+  conversations: Conversation[] | null | undefined,
+  activeConversationId: string | null,
+): ConversationHistory {
+  return useMemo(() => {
+    const conversationList = conversations ?? [];
+    const conversationCount = conversationList.length;
+
+    const activeConversation =
+      conversationList.find((conversation) => conversation.id === activeConversationId) ?? null;
+
+    const sortedConversations = [...conversationList].sort((a, b) => {
+      const getTimestamp = (conversation: Conversation) =>
+        new Date(conversation.updatedAt ?? conversation.createdAt ?? 0).getTime();
+
+      return getTimestamp(b) - getTimestamp(a);
+    });
+
+    const formatConversationDate = (conversation: Conversation) => {
+      const referenceDate = conversation.updatedAt || conversation.createdAt;
+      if (!referenceDate) return "Unbekannt";
+
+      return new Date(referenceDate).toLocaleDateString("de-DE", {
+        day: "2-digit",
+        month: "short",
+      });
+    };
+
+    const historyPages = sortedConversations.map((conversation) => ({
+      id: conversation.id,
+      title: conversation.title || "Unbenannter Chat",
+      date: formatConversationDate(conversation),
+    }));
+
+    return {
+      conversationList,
+      conversationCount,
+      activeConversation,
+      historyPages,
+      activeHistoryPages: historyPages.slice(0, 3),
+      archivedHistoryPages: historyPages.slice(3),
+    };
+  }, [activeConversationId, conversations]);
+}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -14,6 +14,7 @@ import { QUICKSTARTS } from "../config/quickstarts";
 import { useRoles } from "../contexts/RolesContext";
 import { useConversationStats } from "../hooks/use-storage";
 import { useChat } from "../hooks/useChat";
+import { useConversationHistory } from "../hooks/useConversationHistory";
 import { useConversationManager } from "../hooks/useConversationManager";
 import { useMemory } from "../hooks/useMemory";
 import { useSettings } from "../hooks/useSettings";
@@ -226,8 +227,10 @@ export default function Chat() {
     }
   }, [searchParams, navigate, startWithPreset]);
 
-  const activeConversation = conversations?.find((c) => c.id === activeConversationId);
-  const conversationCount = conversations?.length ?? 0;
+  const { activeConversation, conversationCount } = useConversationHistory(
+    conversations,
+    activeConversationId,
+  );
 
   const handleStartNewChat = useCallback(() => {
     newConversation();


### PR DESCRIPTION
## Summary
- extract conversation history sorting and formatting into a dedicated hook
- update Chat page to consume the new hook for active conversation and counts

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f383dc71c8320a51cca3775efdbcb)