### PR TITLE
Add quick-start chips to chat start card

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { useToasts } from "@/ui";
 import { Button } from "@/ui/Button";
-import { ChatStartCard } from "@/ui/ChatStartCard";
+import { ChatStartCard, type QuickStartItem } from "@/ui/ChatStartCard";
 
 import { ChatInputBar } from "../components/chat/ChatInputBar";
 import { ChatStatusBanner } from "../components/chat/ChatStatusBanner";
@@ -241,6 +241,18 @@ export default function Chat() {
     void navigate("/chat/history");
   }, [navigate]);
 
+  const quickStartPrompts: QuickStartItem[] = [
+    { label: "Frag mich nach Ideen", prompt: "Welche Ideen hast du für unser nächstes Feature?" },
+    {
+      label: "Hilf mir bei Text",
+      prompt: "Formuliere mir bitte eine freundliche Nachricht an unser Team.",
+    },
+    {
+      label: "Strukturiere einen Plan",
+      prompt: "Erstelle mir eine kurze Liste der nächsten Schritte.",
+    },
+  ];
+
   const isEmpty = messages.length === 0;
 
   return (
@@ -305,6 +317,8 @@ export default function Chat() {
           {isEmpty ? (
             <ChatStartCard
               onNewChat={handleStartNewChat}
+              onQuickStart={handleFollowUp}
+              quickStarts={quickStartPrompts}
               conversationCount={stats?.totalConversations ?? conversationCount}
             />
           ) : (

--- a/src/ui/ChatStartCard.tsx
+++ b/src/ui/ChatStartCard.tsx
@@ -4,6 +4,11 @@ import { BrandWordmark } from "../app/components/BrandWordmark";
 import { History, Sparkles } from "../lib/icons";
 import { buttonVariants } from "./Button";
 
+export interface QuickStartItem {
+  label: string;
+  prompt: string;
+}
+
 /**
  * ChatStartCard - Tinte auf Papier Stil
  *
@@ -13,10 +18,23 @@ import { buttonVariants } from "./Button";
 
 interface ChatStartCardProps {
   onNewChat: () => void;
+  onQuickStart?: (prompt: string) => void;
   conversationCount?: number;
+  quickStarts?: QuickStartItem[];
 }
 
-export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCardProps) {
+const DEFAULT_QUICK_STARTS: QuickStartItem[] = [
+  { label: "Frag mich nach Ideen", prompt: "Welche Ideen hast du für mein nächstes Projekt?" },
+  { label: "Hilf mir bei Text", prompt: "Kannst du mir einen kurzen Teaser formulieren?" },
+  { label: "Erkläre mir etwas", prompt: "Erkläre mir dieses Thema so, dass es ein Kind versteht." },
+];
+
+export function ChatStartCard({
+  onNewChat,
+  onQuickStart,
+  conversationCount = 0,
+  quickStarts = DEFAULT_QUICK_STARTS,
+}: ChatStartCardProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-border-ink/30 bg-surface-2 px-6 py-8 text-center shadow-sm">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-accent-primary/10 text-accent-primary">
@@ -29,6 +47,24 @@ export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCar
         Starte ein neues Gespräch oder setze eine Unterhaltung fort. Schlanke Eingabeleiste, klare
         Kontraste und fokussierte Aktionen sorgen für Ruhe im Flow.
       </p>
+
+      {quickStarts.length > 0 && (
+        <div className="flex w-full flex-wrap items-center justify-center gap-2 sm:gap-3">
+          {quickStarts.slice(0, 3).map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              onClick={() => {
+                onNewChat();
+                onQuickStart?.(item.prompt);
+              }}
+              className="rounded-full border border-border-ink/40 bg-surface-1 px-4 py-2 text-xs font-medium text-text-primary transition hover:border-border-ink/70 hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="flex w-full max-w-md flex-col gap-3 sm:flex-row">
         <button


### PR DESCRIPTION
## Summary
- add configurable quick-start chips to the ChatStartCard with default prompts
- allow quick-start selections to trigger new chat creation and follow-up sending in Chat
- continue showing conversation history CTA while hiding the card once messages appear

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f53c90b4c8320affa24841f934b9e)