### PR TITLE
Compact chat context bar controls

### DIFF
--- a/src/components/chat/ContextBar/ContextBadge.tsx
+++ b/src/components/chat/ContextBar/ContextBadge.tsx
@@ -14,7 +14,8 @@ export const ContextBadge = forwardRef<HTMLButtonElement, ContextBadgeProps>(
       ref={ref}
       type="button"
       className={cn(
-        "inline-flex items-center gap-1 rounded-full border border-border-ink bg-surface-1 px-3 py-1.5 text-xs font-medium text-ink-primary",
+        "inline-flex min-w-0 max-w-[160px] items-center gap-1 rounded-full border border-border-ink bg-surface-1 px-2.5 py-1.5",
+        "text-[11px] font-medium uppercase tracking-wide text-ink-primary",
         "transition-all duration-200 hover:bg-surface-2 active:scale-[0.98]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50",
         isOpen && "bg-ink-primary text-surface-1 border-ink-primary",

--- a/src/components/chat/ContextBar/ModelSelector.tsx
+++ b/src/components/chat/ContextBar/ModelSelector.tsx
@@ -19,7 +19,7 @@ export function ModelSelector({ catalog }: ModelSelectorProps) {
   // Find current label - shortened for mobile
   const currentModel = catalog?.find((m) => m.id === settings.preferredModelId);
   const fullLabel = currentModel?.label || settings.preferredModelId.split("/").pop() || "Auto";
-  const label = `Modell: ${fullLabel}`;
+  const label = currentModel?.label || settings.preferredModelId.split("/").pop() || "Modell";
 
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
@@ -28,7 +28,7 @@ export function ModelSelector({ catalog }: ModelSelectorProps) {
           label={label}
           isOpen={open}
           aria-label={`Aktuelles Modell: ${fullLabel}. Ändern…`}
-          className="max-w-[200px]"
+          className="max-w-[150px] sm:max-w-[180px]"
         />
       </DropdownMenu.Trigger>
 

--- a/src/components/chat/ContextBar/PersonaSelector.tsx
+++ b/src/components/chat/ContextBar/PersonaSelector.tsx
@@ -14,7 +14,11 @@ export function PersonaSelector() {
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
-        <ContextBadge label={`Rolle: ${activeRole?.name || "Standard"}`} isOpen={open} />
+        <ContextBadge
+          label={activeRole?.name || "Rolle"}
+          isOpen={open}
+          className="max-w-[140px] sm:max-w-[170px]"
+        />
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>

--- a/src/components/chat/ContextBar/QuickSettingsDropdown.tsx
+++ b/src/components/chat/ContextBar/QuickSettingsDropdown.tsx
@@ -1,10 +1,18 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useSettings } from "@/hooks/useSettings";
+import { Check, SlidersHorizontal } from "@/lib/icons";
 import { cn } from "@/lib/utils";
+import { discussionPresetOptions } from "@/prompts/discussion/presets";
+import { Button } from "@/ui/Button";
 
-import { ContextBadge } from "./ContextBadge";
+const CREATIVITY_OPTIONS = [
+  { label: "Niedrig", value: 20 },
+  { label: "Ausgewogen", value: 45 },
+  { label: "Kreativ", value: 70 },
+  { label: "Maximal", value: 90 },
+] as const;
 
 const CONTEXT_OPTIONS = [
   { label: "Kurz", value: 5 },
@@ -12,69 +20,150 @@ const CONTEXT_OPTIONS = [
   { label: "Lang", value: 12 },
 ] as const;
 
-/**
- * QuickSettingsDropdown: AI Behavior Settings
- * Only includes settings that affect AI behavior (not UI preferences).
- *
- * Current settings:
- * - Antwortlänge (Context Length): Controls how long/detailed AI responses should be
- */
-export function ContextLengthSelector() {
+export function QuickSettingsDropdown() {
   const [open, setOpen] = useState(false);
-  const { settings, setDiscussionMaxSentences } = useSettings();
+  const { settings, setCreativity, setDiscussionMaxSentences, setDiscussionPreset } = useSettings();
 
-  const currentOption = CONTEXT_OPTIONS.find((option) => {
-    if (option.value === 5) return settings.discussionMaxSentences <= 5;
-    if (option.value === 8)
-      return settings.discussionMaxSentences > 5 && settings.discussionMaxSentences < 12;
-    return settings.discussionMaxSentences >= 12;
-  });
+  const currentCreativity = useMemo(
+    () =>
+      CREATIVITY_OPTIONS.reduce((prev, curr) =>
+        Math.abs(curr.value - settings.creativity) < Math.abs(prev.value - settings.creativity)
+          ? curr
+          : prev,
+      ),
+    [settings.creativity],
+  );
+
+  const currentContext = useMemo(() => {
+    const option = CONTEXT_OPTIONS.find((item) => {
+      if (item.value === 5) return settings.discussionMaxSentences <= 5;
+      if (item.value === 8)
+        return settings.discussionMaxSentences > 5 && settings.discussionMaxSentences < 12;
+      return settings.discussionMaxSentences >= 12;
+    });
+
+    return option ?? CONTEXT_OPTIONS[1];
+  }, [settings.discussionMaxSentences]);
+
+  const currentPreset = useMemo(
+    () =>
+      discussionPresetOptions.find((option) => option.key === settings.discussionPreset) ??
+      discussionPresetOptions[0] ?? {
+        key: "freundlich_offen",
+        label: "Stil",
+      },
+    [settings.discussionPreset],
+  );
 
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
-        <ContextBadge
-          label={`Kontextlänge: ${currentOption?.label ?? "Mittel"}`}
-          isOpen={open}
-          aria-label="Antwortlänge einstellen"
-          className="max-w-[200px]"
-        />
+        <Button
+          variant="secondary"
+          size="icon"
+          className="h-10 w-10 rounded-xl border border-border-ink bg-surface-1 text-ink-primary hover:bg-surface-2"
+          aria-label="Schnelleinstellungen"
+          title="Stil, Kreativität und Kontext"
+        >
+          <SlidersHorizontal className="h-4.5 w-4.5" />
+        </Button>
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           className={cn(
-            "z-popover min-w-[200px] rounded-xl border border-border-ink bg-bg-page/95 p-1 shadow-floating backdrop-blur-sm",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+            "z-popover w-[260px] rounded-xl border border-border-ink bg-bg-page/95 p-1 shadow-floating backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
           )}
           side="top"
-          sideOffset={8}
+          sideOffset={10}
           align="end"
           collisionPadding={8}
         >
-          {CONTEXT_OPTIONS.map((option) => (
-            <DropdownMenu.Item
-              key={option.value}
-              onSelect={() => {
-                setDiscussionMaxSentences(option.value);
-                setOpen(false);
-              }}
-              className={cn(
-                "flex select-none items-center justify-between rounded-md px-3 py-2 text-sm outline-none transition-colors",
-                "hover:bg-surface-2 focus:bg-surface-2 data-[highlighted]:bg-surface-2",
-                ((option.value === 5 && settings.discussionMaxSentences <= 5) ||
+          <div className="flex flex-col gap-1.5">
+            <DropdownMenu.Label className="px-3 pt-2 text-[11px] font-semibold uppercase tracking-wide text-ink-tertiary">
+              Schnelleinstellungen
+            </DropdownMenu.Label>
+
+            <Section
+              title="Stil"
+              value={currentPreset.label}
+              items={discussionPresetOptions.map((preset) => ({
+                key: preset.key,
+                label: preset.label,
+                onSelect: () => setDiscussionPreset(preset.key),
+                active: settings.discussionPreset === preset.key,
+              }))}
+            />
+
+            <DropdownMenu.Separator className="mx-3 h-px bg-border-ink/60" />
+
+            <Section
+              title="Kreativ"
+              value={currentCreativity.label}
+              items={CREATIVITY_OPTIONS.map((option) => ({
+                key: option.value.toString(),
+                label: option.label,
+                onSelect: () => setCreativity(option.value),
+                active: Math.abs(settings.creativity - option.value) < 5,
+              }))}
+            />
+
+            <DropdownMenu.Separator className="mx-3 h-px bg-border-ink/60" />
+
+            <Section
+              title="Länge"
+              value={currentContext.label}
+              items={CONTEXT_OPTIONS.map((option) => ({
+                key: option.value.toString(),
+                label: option.label,
+                onSelect: () => setDiscussionMaxSentences(option.value),
+                active:
+                  (option.value === 5 && settings.discussionMaxSentences <= 5) ||
                   (option.value === 8 &&
                     settings.discussionMaxSentences > 5 &&
                     settings.discussionMaxSentences < 12) ||
-                  (option.value === 12 && settings.discussionMaxSentences >= 12)) &&
-                  "bg-surface-1",
-              )}
-            >
-              <span className="truncate text-left">{option.label}</span>
-            </DropdownMenu.Item>
-          ))}
+                  (option.value === 12 && settings.discussionMaxSentences >= 12),
+              }))}
+            />
+          </div>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  value: string;
+  items: { key: string; label: string; onSelect: () => void; active: boolean }[];
+}
+
+function Section({ title, value, items }: SectionProps) {
+  return (
+    <div className="px-1 pb-1">
+      <div className="flex items-center justify-between px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-ink-secondary">
+        <span>{title}</span>
+        <span className="truncate text-ink-tertiary">{value}</span>
+      </div>
+      <div className="rounded-lg border border-border-ink/70 bg-surface-1/60">
+        {items.map((item, index) => (
+          <DropdownMenu.Item
+            key={item.key}
+            onSelect={() => item.onSelect()}
+            className={cn(
+              "flex select-none items-center justify-between px-3 py-2 text-sm outline-none transition-colors",
+              "hover:bg-surface-2 focus:bg-surface-2 data-[highlighted]:bg-surface-2",
+              index !== items.length - 1 && "border-b border-border-ink/50",
+              item.active && "bg-surface-1",
+            )}
+          >
+            <span className="truncate text-left">{item.label}</span>
+            {item.active && <Check className="h-3.5 w-3.5 text-accent-primary" />}
+          </DropdownMenu.Item>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/chat/ContextBar/index.tsx
+++ b/src/components/chat/ContextBar/index.tsx
@@ -3,11 +3,9 @@ import { Send, Square } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/Button";
 
-import { CreativitySelector } from "./CreativityDropdown";
 import { ModelSelector } from "./ModelSelector";
 import { PersonaSelector } from "./PersonaSelector";
-import { ContextLengthSelector } from "./QuickSettingsDropdown";
-import { StyleSelector } from "./StyleDropdown";
+import { QuickSettingsDropdown } from "./QuickSettingsDropdown";
 
 interface ContextBarProps {
   modelCatalog: ModelEntry[] | null;
@@ -34,17 +32,16 @@ export function ContextBar({
         className,
       )}
     >
-      <div className="flex-1 overflow-x-auto">
-        <div className="flex min-w-max items-center gap-2 pr-1">
+      <div className="flex-1 min-w-0 overflow-hidden">
+        <div className="flex flex-wrap items-center gap-1.5 pr-1">
           <PersonaSelector />
-          <StyleSelector />
-          <CreativitySelector />
-          <ContextLengthSelector />
           <ModelSelector catalog={modelCatalog} />
         </div>
       </div>
 
       <div className="flex-shrink-0 flex items-center gap-1.5 sm:gap-2">
+        <QuickSettingsDropdown />
+
         {isLoading ? (
           <Button
             onClick={onStop}


### PR DESCRIPTION
## Summary
- shorten chat context badges and constrain their width for better fit on small screens
- consolidate style, creativity, and context length controls into a single quick settings dropdown beside send actions
- adjust ContextBar layout to wrap and keep controls compact on mobile

## Testing
- npm run verify


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f53cada5c832095145d8d56b648a8)