### PR TITLE
Add chat control bar for composer settings

### DIFF
--- a/src/components/chat/ChatControlBar.tsx
+++ b/src/components/chat/ChatControlBar.tsx
@@ -1,0 +1,203 @@
+import { type ComponentType, useMemo } from "react";
+
+import type { ModelEntry } from "@/config/models";
+import { useRoles } from "@/contexts/RolesContext";
+import { useMemory } from "@/hooks/useMemory";
+import { useSettings } from "@/hooks/useSettings";
+import { Brain, Cpu, Feather, Sparkles, User } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+} from "@/ui/Select";
+import { Switch } from "@/ui/Switch";
+
+const CREATIVE_STYLES = [
+  { id: 10, label: "Präzise" },
+  { id: 45, label: "Ausgewogen" },
+  { id: 80, label: "Kreativ" },
+];
+
+interface ChatControlBarProps {
+  modelCatalog: ModelEntry[] | null;
+  className?: string;
+}
+
+function ControlLabel({
+  icon: Icon,
+  label,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-ink-tertiary">
+      <Icon className="h-3.5 w-3.5" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export function ChatControlBar({ modelCatalog, className }: ChatControlBarProps) {
+  const { roles, activeRole, setActiveRole } = useRoles();
+  const { settings, setPreferredModel, setCreativity } = useSettings();
+  const { isEnabled: memoryEnabled, toggleMemory } = useMemory();
+
+  const modelOptions = useMemo(() => {
+    if (modelCatalog && modelCatalog.length > 0) return modelCatalog;
+    if (settings.preferredModelId) {
+      return [
+        {
+          id: settings.preferredModelId,
+          label: settings.preferredModelId,
+          tags: [],
+          safety: "any",
+        } as ModelEntry,
+      ];
+    }
+    return [] as ModelEntry[];
+  }, [modelCatalog, settings.preferredModelId]);
+
+  const activeStyleLabel =
+    CREATIVE_STYLES.find((style) => style.id === (settings.creativity ?? 45))?.label ??
+    "Ausgewogen";
+
+  return (
+    <div
+      className={cn("w-full bg-bg-page/95 backdrop-blur border-b border-border-ink/10", className)}
+    >
+      <div className="mx-auto flex w-full max-w-3xl flex-wrap gap-2 px-3 py-3 sm:gap-3 sm:px-4 md:grid md:grid-cols-3">
+        <Select
+          value={activeRole?.id ?? "none"}
+          onValueChange={(value) => {
+            if (value === "none") {
+              setActiveRole(null);
+              return;
+            }
+            const role = roles.find((r) => r.id === value);
+            setActiveRole(role ?? null);
+          }}
+        >
+          <SelectTrigger aria-label="Rolle auswählen" className="min-h-[44px] text-left">
+            <div className="flex w-full items-center gap-2 truncate">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-2 text-ink-secondary">
+                <User className="h-4 w-4" />
+              </div>
+              <div className="flex flex-col truncate text-start">
+                <ControlLabel icon={User} label="Rolle" />
+                <span className="truncate text-sm font-medium text-ink-primary">
+                  {activeRole?.name ?? "Keine Rolle"}
+                </span>
+              </div>
+            </div>
+          </SelectTrigger>
+          <SelectContent align="start">
+            <SelectGroup>
+              <SelectLabel>Rollen</SelectLabel>
+              <SelectItem value="none">Standard (Keine)</SelectItem>
+              {roles.map((role) => (
+                <SelectItem key={role.id} value={role.id}>
+                  {role.name}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={String(settings.creativity ?? 45)}
+          onValueChange={(value) => {
+            if (value === "memory-toggle") {
+              toggleMemory();
+              return;
+            }
+            const numericValue = Number(value);
+            if (!Number.isNaN(numericValue)) {
+              setCreativity(numericValue);
+            }
+          }}
+        >
+          <SelectTrigger aria-label="Stil und Gedächtnis" className="min-h-[44px] text-left">
+            <div className="flex w-full items-center gap-2 truncate">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-2 text-ink-secondary">
+                <Sparkles className="h-4 w-4" />
+              </div>
+              <div className="flex flex-col truncate text-start">
+                <ControlLabel icon={Feather} label="Stil & Gedächtnis" />
+                <span className="truncate text-sm font-medium text-ink-primary">
+                  {activeStyleLabel}
+                  <span className="text-ink-tertiary">
+                    {" "}
+                    • {memoryEnabled ? "Memory an" : "Memory aus"}
+                  </span>
+                </span>
+              </div>
+            </div>
+          </SelectTrigger>
+          <SelectContent align="start">
+            <SelectGroup>
+              <SelectLabel>Stil</SelectLabel>
+              {CREATIVE_STYLES.map((style) => (
+                <SelectItem key={style.id} value={String(style.id)}>
+                  {style.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+            <SelectSeparator />
+            <div className="flex items-center justify-between gap-3 px-3 py-2 text-sm text-ink-primary">
+              <div className="flex items-center gap-2">
+                <Brain className="h-4 w-4 text-ink-secondary" />
+                <span>Gedächtnis</span>
+              </div>
+              <Switch
+                checked={memoryEnabled}
+                onCheckedChange={toggleMemory}
+                aria-label="Gedächtnis umschalten"
+              />
+            </div>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={settings.preferredModelId}
+          onValueChange={(value) => setPreferredModel(value)}
+          disabled={modelCatalog === null && modelOptions.length === 0}
+        >
+          <SelectTrigger aria-label="Modell auswählen" className="min-h-[44px] text-left">
+            <div className="flex w-full items-center gap-2 truncate">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-2 text-ink-secondary">
+                <Cpu className="h-4 w-4" />
+              </div>
+              <div className="flex flex-col truncate text-start">
+                <ControlLabel icon={Cpu} label="Modell" />
+                <span className="truncate text-sm font-medium text-ink-primary">
+                  {modelOptions.find((model) => model.id === settings.preferredModelId)?.label ??
+                    settings.preferredModelId}
+                </span>
+              </div>
+            </div>
+          </SelectTrigger>
+          <SelectContent align="start">
+            <SelectGroup>
+              <SelectLabel>Modelle</SelectLabel>
+              {modelOptions.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-ink-secondary">Keine Modelle verfügbar</div>
+              ) : (
+                modelOptions.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.label ?? model.id}
+                  </SelectItem>
+                ))
+              )}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/UnifiedInputBar.tsx
+++ b/src/components/chat/UnifiedInputBar.tsx
@@ -6,8 +6,6 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/ui/Button";
 import { Textarea } from "@/ui/Textarea";
 
-import { ChatSettingsDropup } from "./ChatSettingsDropup";
-
 export interface UnifiedInputBarProps {
   value: string;
   onChange: (value: string) => void;
@@ -62,19 +60,14 @@ export function UnifiedInputBar({
 
   return (
     <div
-      className={cn("w-full transition-[padding] bg-bg-page", className)}
+      className={cn("w-full max-w-3xl mx-auto transition-[padding] px-3 sm:px-4", className)}
       style={{
-        paddingBottom: "max(var(--keyboard-offset, 0px), env(safe-area-inset-bottom, 0px))",
+        paddingBottom:
+          "calc(max(var(--keyboard-offset, 0px), env(safe-area-inset-bottom, 0px)) + 0.5rem)",
       }}
     >
-      <div className="flex items-end gap-2 p-2 sm:gap-3 sm:p-3 md:max-w-3xl md:mx-auto">
-        {/* Left: Settings Dropup */}
-        <div className="flex-shrink-0 mb-1">
-          <ChatSettingsDropup />
-        </div>
-
-        {/* Center: Text Input (Paper Style) */}
-        <div className="relative flex-1 rounded-2xl bg-surface-1 border border-border-ink shadow-sm transition-shadow focus-within:shadow-md focus-within:border-ink-primary/30">
+      <div className="flex items-end gap-2 rounded-2xl border border-border-ink bg-surface-1 p-2 shadow-sm transition-shadow focus-within:border-ink-primary/30 focus-within:shadow-md sm:gap-3 sm:p-3">
+        <div className="relative flex-1">
           <Textarea
             ref={textareaRef}
             value={value}
@@ -82,14 +75,13 @@ export function UnifiedInputBar({
             onKeyDown={handleKeyDown}
             placeholder="Schreibe..."
             aria-label="Nachricht eingeben"
-            className="w-full min-h-[40px] max-h-[180px] bg-transparent border-0 focus-visible:ring-0 px-4 py-3 resize-none text-base text-ink-primary placeholder:text-ink-tertiary leading-relaxed"
+            className="w-full min-h-[40px] max-h-[180px] resize-none border-0 bg-transparent px-3 py-2 text-base leading-relaxed text-ink-primary placeholder:text-ink-tertiary focus-visible:ring-0 sm:px-4 sm:py-3"
             rows={1}
             data-testid="composer-input"
           />
         </div>
 
-        {/* Right: Send Button */}
-        <div className="flex-shrink-0 mb-1">
+        <div className="flex-shrink-0">
           <Button
             onClick={onSend}
             disabled={!value.trim() || isLoading}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useToasts } from "@/ui";
 import { ChatStartCard } from "@/ui/ChatStartCard";
 
+import { ChatControlBar } from "../components/chat/ChatControlBar";
 import { ChatStatusBanner } from "../components/chat/ChatStatusBanner";
 import { UnifiedInputBar } from "../components/chat/UnifiedInputBar";
 import { VirtualizedMessageList } from "../components/chat/VirtualizedMessageList";
@@ -263,6 +264,7 @@ export default function Chat() {
         onMenuClick={openMenu}
         onBookmarkClick={() => setIsHistoryOpen(true)}
       >
+        <h1 className="sr-only">Disa AI – Chat</h1>
         <BookPageAnimator pageKey={activeConversationId || "new"}>
           <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
 
@@ -296,6 +298,7 @@ export default function Chat() {
 
             {/* Unified Input Area */}
             <div className="z-sticky-content bg-bg-page/95 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md border-t border-border-ink/10">
+              <ChatControlBar modelCatalog={modelCatalog} />
               <UnifiedInputBar
                 value={input}
                 onChange={setInput}

--- a/tests/e2e/book-concept.spec.ts
+++ b/tests/e2e/book-concept.spec.ts
@@ -19,8 +19,10 @@ test.describe("Book Concept UI", () => {
     const input = page.getByTestId("composer-input");
     await expect(input).toBeVisible();
 
-    // Check for Settings Dropup Trigger
-    await expect(page.locator('button[aria-label="Chat Einstellungen"]')).toBeVisible();
+    // Check for control bar dropdowns
+    await expect(page.getByRole("button", { name: "Rolle auswählen" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Stil und Gedächtnis" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Modell auswählen" })).toBeVisible();
   });
 
   test("should allow typing and sending a message", async ({ page }) => {
@@ -41,25 +43,18 @@ test.describe("Book Concept UI", () => {
     await expect(page.getByText("Hello Book World")).toBeVisible();
   });
 
-  test("should open and interact with Settings Dropup", async ({ page }) => {
-    const settingsButton = page.locator('button[aria-label="Chat Einstellungen"]');
-    await settingsButton.click();
+  test("should open and interact with Control Bar", async ({ page }) => {
+    const styleControl = page.getByRole("button", { name: "Stil und Gedächtnis" });
+    await styleControl.click();
 
-    // Dropup should be visible
-    const dropup = page.locator(".z-popover"); // Based on class used in ChatSettingsDropup
-    await expect(dropup).toBeVisible();
-
-    // Check for sections
-    await expect(dropup.getByText("Modell")).toBeVisible();
-    await expect(dropup.getByText("Rolle")).toBeVisible();
-    await expect(dropup.getByText("Stil")).toBeVisible();
-
-    // Select a style (e.g., "Kreativ")
-    const creativeOption = dropup.getByRole("button", { name: "Kreativ" });
+    const creativeOption = page.getByRole("option", { name: "Kreativ" });
+    await expect(creativeOption).toBeVisible();
     await creativeOption.click();
 
-    // Dropup should close
-    await expect(dropup).not.toBeVisible();
+    await styleControl.click();
+    const memorySwitch = page.getByRole("switch", { name: "Gedächtnis umschalten" });
+    await expect(memorySwitch).toBeVisible();
+    await memorySwitch.click();
   });
 
   test("should open History Panel via Bookmark", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add ChatControlBar with role, style/memory, and model selectors above the chat composer
- simplify UnifiedInputBar to focus on text entry and sending
- update chat page layout and e2e checks for new controls

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300b818ba4832087e25cb66967dbff)