### PR TITLE
feat: add shared model catalog provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Router } from "./app/router";
 import { FullPageLoader } from "./components/FullPageLoader";
 import { OnboardingOverlay } from "./components/onboarding/OnboardingOverlay";
 import { FavoritesProvider } from "./contexts/FavoritesContext";
+import { ModelCatalogProvider } from "./contexts/ModelCatalogContext";
 import { RolesProvider } from "./contexts/RolesContext";
 import { useServiceWorker } from "./hooks/useServiceWorker";
 import { useSettings } from "./hooks/useSettings";
@@ -162,11 +163,13 @@ export default function App() {
   return (
     <TooltipProvider>
       <RolesProvider>
-        <FavoritesProvider>
-          <ToastsProvider>
-            <AppContent />
-          </ToastsProvider>
-        </FavoritesProvider>
+        <ModelCatalogProvider>
+          <FavoritesProvider>
+            <ToastsProvider>
+              <AppContent />
+            </ToastsProvider>
+          </FavoritesProvider>
+        </ModelCatalogProvider>
       </RolesProvider>
     </TooltipProvider>
   );

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -11,8 +11,8 @@ import { AppMenuDrawer, useMenuDrawer } from "../components/layout/AppMenuDrawer
 import { BookLayout } from "../components/layout/BookLayout";
 import { BookPageAnimator } from "../components/navigation/BookPageAnimator";
 import { HistorySidePanel } from "../components/navigation/HistorySidePanel";
-import type { ModelEntry } from "../config/models";
 import { QUICKSTARTS } from "../config/quickstarts";
+import { useModelCatalog } from "../contexts/ModelCatalogContext";
 import { useRoles } from "../contexts/RolesContext";
 import { useConversationStats } from "../hooks/use-storage";
 import { useChat } from "../hooks/useChat";
@@ -37,35 +37,14 @@ export default function Chat() {
   const [searchParams] = useSearchParams();
   const { isEnabled: memoryEnabled } = useMemory();
   const { stats } = useConversationStats();
-  const [modelCatalog, setModelCatalog] = useState<ModelEntry[] | null>(null);
+  const { models: modelCatalog } = useModelCatalog();
 
   // UI State
   const { isOpen: isMenuOpen, openMenu, closeMenu } = useMenuDrawer();
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
-  useEffect(() => {
-    let active = true;
-    const isTestEnv = typeof (globalThis as any).vitest !== "undefined";
-    if (typeof window === "undefined" || isTestEnv || typeof window.fetch === "undefined") return;
-    import("../config/models")
-      .then((mod) =>
-        mod.loadModelCatalog().then((data) => {
-          if (!active) return;
-          setModelCatalog(data);
-        }),
-      )
-      .catch(() => {
-        if (!active) return;
-        setModelCatalog(null);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, []);
-
   const requestOptions = useMemo(() => {
-    const capabilities = getSamplingCapabilities(settings.preferredModelId, modelCatalog);
+    const capabilities = getSamplingCapabilities(settings.preferredModelId, modelCatalog ?? null);
     const params = mapCreativityToParams(settings.creativity ?? 45, settings.preferredModelId);
     return {
       model: settings.preferredModelId,
@@ -263,6 +242,7 @@ export default function Chat() {
         onMenuClick={openMenu}
         onBookmarkClick={() => setIsHistoryOpen(true)}
       >
+        <h1 className="sr-only">Disa AI – Chat</h1>
         <BookPageAnimator pageKey={activeConversationId || "new"}>
           <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
 

--- a/tests/smoke/entrypoints.smoke.test.tsx
+++ b/tests/smoke/entrypoints.smoke.test.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
+import { ModelCatalogProvider } from "../../src/contexts/ModelCatalogContext";
 import { RolesProvider } from "../../src/contexts/RolesContext";
 import { ToastsProvider } from "../../src/ui/toast";
 
@@ -133,11 +134,13 @@ function renderWithRouter(pathname: string, element: React.ReactElement) {
   return render(
     <ToastsProvider>
       <RolesProvider>
-        <MemoryRouter initialEntries={[pathname]}>
-          <Routes>
-            <Route path={pathname} element={element} />
-          </Routes>
-        </MemoryRouter>
+        <ModelCatalogProvider>
+          <MemoryRouter initialEntries={[pathname]}>
+            <Routes>
+              <Route path={pathname} element={element} />
+            </Routes>
+          </MemoryRouter>
+        </ModelCatalogProvider>
       </RolesProvider>
     </ToastsProvider>,
   );


### PR DESCRIPTION
## Summary
- introduce a shared model catalog context/hook that caches catalog loading and exposes loading/error state
- switch chat settings and chat request options to use the shared catalog data with loading/error UI feedback and an accessible heading
- wrap the app and smoke tests with the new provider to avoid duplicate fetches and centralize model data

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300b821260832082fc8a2afd2c67aa)