### PR TITLE
Refactor chat layout scrolling surface

### DIFF
--- a/src/components/chat/VirtualizedMessageList.tsx
+++ b/src/components/chat/VirtualizedMessageList.tsx
@@ -30,6 +30,7 @@ interface VirtualizedMessageListProps {
   initialRenderCount?: number;
   loadMoreCount?: number;
   virtualizationThreshold?: number;
+  scrollContainerRef?: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 export function VirtualizedMessageList({
@@ -43,11 +44,13 @@ export function VirtualizedMessageList({
   initialRenderCount = 50,
   loadMoreCount = 30,
   virtualizationThreshold = 20,
+  scrollContainerRef,
 }: VirtualizedMessageListProps) {
   const [visibleCount, setVisibleCount] = useState(initialRenderCount);
   const { scrollRef, isSticking, scrollToBottom } = useStickToBottom({
     threshold: 0.8,
     enabled: true,
+    containerRef: scrollContainerRef,
   });
 
   const { visibleMessages, shouldVirtualize, hiddenCount } = useMemo(() => {
@@ -97,14 +100,20 @@ export function VirtualizedMessageList({
     [onRetry],
   );
 
+  const attachInternalRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!scrollContainerRef) {
+        scrollRef.current = node;
+      }
+    },
+    [scrollContainerRef, scrollRef],
+  );
+
   return (
-    <div data-testid="message-list">
+    <div data-testid="message-list" className={cn("h-full", className)}>
       <div
-        ref={scrollRef}
-        className={cn("chat-scroll-area flex-1 overflow-y-auto scroll-smooth", className)}
-        role="log"
-        aria-label="Chat messages"
-        data-testid="virtualized-chat-log"
+        ref={scrollContainerRef ? undefined : attachInternalRef}
+        className="chat-scroll-area h-full"
       >
         {shouldVirtualize && hiddenCount > 0 && (
           <div className="sticky top-0 z-sticky-content flex justify-center bg-[var(--bg0)] py-2">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -38,6 +38,7 @@ export default function Chat() {
   const { isEnabled: memoryEnabled } = useMemory();
   const { stats } = useConversationStats();
   const [modelCatalog, setModelCatalog] = useState<ModelEntry[] | null>(null);
+  const chatScrollRef = useRef<HTMLDivElement>(null);
 
   // UI State
   const { isOpen: isMenuOpen, openMenu, closeMenu } = useMenuDrawer();
@@ -264,13 +265,19 @@ export default function Chat() {
         onBookmarkClick={() => setIsHistoryOpen(true)}
       >
         <BookPageAnimator pageKey={activeConversationId || "new"}>
-          <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
+          <div className="flex h-[calc(var(--vh,1vh)*100)] flex-col">
+            <h1 className="sr-only">Disa AI – Chat</h1>
+            <ChatStatusBanner status={apiStatus} error={error} rateLimitInfo={rateLimitInfo} />
 
-          <div className="flex flex-1 flex-col h-full relative overflow-hidden">
-            {/* Scroll Area */}
-            <div className="flex-1 overflow-y-auto px-3 py-3 sm:px-8 sm:py-6 scroll-smooth">
+            <main
+              ref={chatScrollRef}
+              className="scroll-smooth flex-1 overflow-y-auto px-3 py-3 sm:px-8 sm:py-6 min-h-0"
+              role="log"
+              aria-label="Chat messages"
+              data-testid="virtualized-chat-log"
+            >
               {isEmpty ? (
-                <div className="max-w-2xl mx-auto mt-8">
+                <div className="mx-auto mt-8 max-w-2xl">
                   <ChatStartCard
                     onNewChat={handleStartNewChat}
                     conversationCount={stats?.totalConversations ?? conversationCount}
@@ -288,21 +295,21 @@ export default function Chat() {
                   onRetry={(_messageId) => {
                     /* TODO: Implement simple retry */ return void 0;
                   }}
-                  className="h-full max-w-3xl mx-auto"
+                  className="mx-auto h-full max-w-3xl"
+                  scrollContainerRef={chatScrollRef}
                 />
               )}
               <div ref={messagesEndRef} />
-            </div>
+            </main>
 
-            {/* Unified Input Area */}
-            <div className="z-sticky-content bg-bg-page/95 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md border-t border-border-ink/10">
+            <footer className="z-sticky-content border-t border-border-ink/10 bg-bg-page/95 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md">
               <UnifiedInputBar
                 value={input}
                 onChange={setInput}
                 onSend={handleSend}
                 isLoading={isLoading}
               />
-            </div>
+            </footer>
           </div>
         </BookPageAnimator>
       </BookLayout>


### PR DESCRIPTION
## Summary
- restructure the chat page container to span the viewport, expose an accessible heading, and place the main chat area and footer in a single flex column
- move scrolling responsibility to the chat page, updating `VirtualizedMessageList` to fill the parent area without its own overflow surface
- allow the stick-to-bottom hook to work with external scroll containers for unified scroll management

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300b810470832091ae4fdc861a3b0a)