### PR TITLE
Validate default model id against catalog

### DIFF
--- a/src/__tests__/modelDefaults.test.ts
+++ b/src/__tests__/modelDefaults.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import modelsMetadata from "../../public/models_metadata.json";
+import { DEFAULT_MODEL_ID, isAllowedModelId } from "../config/modelDefaults";
+
+describe("model defaults", () => {
+  const curatedIds = Object.keys(modelsMetadata);
+  const knownCuratedId = curatedIds[0];
+
+  it("exposes a default model id that is validated against the catalog", () => {
+    if (DEFAULT_MODEL_ID) {
+      expect(isAllowedModelId(DEFAULT_MODEL_ID)).toBe(true);
+    } else {
+      expect(DEFAULT_MODEL_ID).toBe("");
+    }
+  });
+
+  it("accepts curated ids and rejects unknown entries", () => {
+    if (knownCuratedId) {
+      expect(isAllowedModelId(knownCuratedId)).toBe(true);
+    }
+    expect(isAllowedModelId("unknown/provider-model")).toBe(false);
+  });
+
+  it("accepts dynamically supplied models when not part of metadata", () => {
+    expect(isAllowedModelId("custom/model", [{ id: "custom/model" }])).toBe(true);
+  });
+});

--- a/src/config/modelDefaults.ts
+++ b/src/config/modelDefaults.ts
@@ -1,0 +1,18 @@
+import modelsMetadata from "../../public/models_metadata.json";
+
+const curatedModelIds = new Set(Object.keys(modelsMetadata));
+
+type ModelLike = { id: string };
+
+export function isAllowedModelId(
+  modelId: string | null | undefined,
+  availableModels?: ModelLike[],
+): modelId is string {
+  if (!modelId) return false;
+  if (availableModels?.some((model) => model.id === modelId)) return true;
+  return curatedModelIds.has(modelId);
+}
+
+// Kuratiertes Fallback aus public/models_metadata.json; wird auf leer gesetzt, falls entfernt.
+const FALLBACK_MODEL_ID = "deepseek/deepseek-r1:free";
+export const DEFAULT_MODEL_ID = isAllowedModelId(FALLBACK_MODEL_ID) ? FALLBACK_MODEL_ID : "";

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { DEFAULT_MODEL_ID, isAllowedModelId } from "../config/modelDefaults";
 import {
   getDiscussionMaxSentences,
   getDiscussionPreset,
@@ -43,7 +44,7 @@ const DEFAULT_SETTINGS: Settings = {
   enableNeko: false, // Extras sind nun opt-in
   theme: "auto",
   language: "de",
-  preferredModelId: "openai/gpt-4o-mini",
+  preferredModelId: DEFAULT_MODEL_ID || "",
   creativity: 45,
   discussionPreset: "locker_neugierig",
   discussionStrict: false,
@@ -56,6 +57,12 @@ const DEFAULT_SETTINGS: Settings = {
 };
 
 type SettingsUpdater = Partial<Settings> | ((previous: Settings) => Partial<Settings>);
+
+function normalizePreferredModelId(modelId: string | undefined): string {
+  const candidate = modelId ?? DEFAULT_MODEL_ID ?? "";
+  if (!candidate) return "";
+  return isAllowedModelId(candidate) ? candidate : "";
+}
 
 function clampCreativity(value: number | undefined): number {
   const numeric = Number(value);
@@ -88,9 +95,12 @@ function readLegacySettings(): Partial<Settings> {
 }
 
 function normalizeSettings(raw: Partial<Settings>): Settings {
+  const preferredModelId = normalizePreferredModelId(raw.preferredModelId);
+
   return {
     ...DEFAULT_SETTINGS,
     ...raw,
+    preferredModelId,
     creativity: clampCreativity(raw.creativity ?? DEFAULT_SETTINGS.creativity),
     discussionMaxSentences: clampSentences(
       raw.discussionMaxSentences ?? DEFAULT_SETTINGS.discussionMaxSentences,


### PR DESCRIPTION
## Summary
- add a curated, validated default model id derived from the public metadata
- normalize preferred model ids in settings so invalid entries clear instead of falling back
- add unit coverage for the new model id validation helper

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930316a667c832084a5c10d71074f4f)