### PR TITLE
feat(models): validate preferred model selection

### DIFF
--- a/src/components/models/__tests__/resolveInitialModelId.test.ts
+++ b/src/components/models/__tests__/resolveInitialModelId.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { ModelEntry } from "@/config/models";
+
+import { resolveInitialModelId } from "../resolveInitialModelId";
+
+const catalog: ModelEntry[] = [
+  { id: "model-a", label: "Model A", tags: [], safety: "any" },
+  { id: "model-b", label: "Model B", tags: [], safety: "any" },
+];
+
+describe("resolveInitialModelId", () => {
+  it("returns null when catalog is missing", () => {
+    expect(resolveInitialModelId("model-a", null)).toBeNull();
+  });
+
+  it("returns null for empty or whitespace-only ids", () => {
+    expect(resolveInitialModelId("", catalog)).toBeNull();
+    expect(resolveInitialModelId("   ", catalog)).toBeNull();
+  });
+
+  it("returns null when preferred id is not found", () => {
+    expect(resolveInitialModelId("unknown", catalog)).toBeNull();
+  });
+
+  it("returns the preferred id when it exists in catalog", () => {
+    expect(resolveInitialModelId("model-b", catalog)).toBe("model-b");
+  });
+
+  it("normalizes whitespace around the preferred id", () => {
+    expect(resolveInitialModelId(" model-a\n", catalog)).toBe("model-a");
+  });
+});

--- a/src/components/models/resolveInitialModelId.ts
+++ b/src/components/models/resolveInitialModelId.ts
@@ -1,0 +1,13 @@
+import type { ModelEntry } from "@/config/models";
+
+export function resolveInitialModelId(
+  preferredId: string | null | undefined,
+  catalog: ModelEntry[] | null,
+): string | null {
+  if (!catalog || catalog.length === 0) return null;
+  const normalizedPreferredId = preferredId?.trim();
+  if (!normalizedPreferredId) return null;
+
+  const found = catalog.find((entry) => entry.id === normalizedPreferredId);
+  return found ? found.id : null;
+}


### PR DESCRIPTION
## Summary
- add a shared resolveInitialModelId helper so catalog consumers only use valid model ids
- show a neutral CTA when no valid model is resolved and disable model selection when options are missing
- cover the resolver with unit tests for empty and invalid ids

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930316c7bf48320ab7342187c1c8106)