### PR TITLE
feat: apply slate chalk aesthetic

### DIFF
--- a/build-info.json
+++ b/build-info.json
@@ -1,7 +1,7 @@
 {
-  "buildId": "v1.0.0-8b44133",
-  "buildTime": "2025-12-03T18:58:46.596Z",
-  "gitSha": "8b44133f6966524ff8aa0ecb2e462dedd9beb236",
-  "gitBranch": "main",
+  "buildId": "v1.0.0-8df3bd6",
+  "buildTime": "2025-12-03T19:31:38.819Z",
+  "gitSha": "8df3bd68eb67ef258001ab325b4ae0abef4cc261",
+  "gitBranch": "work",
   "version": "1.0.0"
 }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -20,21 +20,21 @@ interface ChatMessageProps {
 
 function CodeBlock({ children, language }: { children: string; language?: string }) {
   return (
-    <div className="relative my-4 overflow-hidden rounded-lg border border-border-ink/30 bg-surface-1">
-      <div className="flex items-center justify-between border-b border-border-ink/20 px-4 py-2">
-        <span className="text-ink-tertiary text-xs font-medium uppercase tracking-wide">
+    <div className="relative my-4 overflow-hidden rounded-xl border border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] shadow-[0_0_0_1px_var(--border-chalk)]">
+      <div className="flex items-center justify-between border-b border-[var(--border-chalk)] px-4 py-2 backdrop-blur-sm">
+        <span className="text-ink-tertiary text-xs font-medium uppercase tracking-[0.08em]">
           {language || "Text"}
         </span>
         <Button
           variant="ghost"
           size="icon"
-          className="text-ink-tertiary hover:bg-surface-2 hover:text-ink-primary h-7 w-7"
+          className="text-ink-tertiary hover:bg-[rgba(255,255,255,0.05)] hover:text-ink-primary h-8 w-8"
           onClick={() => void navigator.clipboard?.writeText(children)}
         >
           <Copy className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <pre className="overflow-x-auto p-4 bg-surface-2/50">
+      <pre className="overflow-x-auto bg-[rgba(0,0,0,0.35)] p-4">
         <code className="text-ink-primary text-sm leading-relaxed font-mono">{children}</code>
       </pre>
     </div>
@@ -100,17 +100,16 @@ export function ChatMessage({
 
   const parsedContent = parseMessageContent(message.content);
 
-  // Tinte auf Papier: User rechts, KI links mit Akzentstreifen
+  // Schiefer & Kreide: feine Kreidelinien auf mattem Schiefer
   const bubbleClass = cn(
-    "relative max-w-[92%] sm:max-w-[85%] md:max-w-[75%] lg:max-w-[65%] xl:max-w-[60%] rounded-md p-3 sm:p-4",
-    // User: rechts, dezent abgesetzter Hintergrund
-    isUser && "ml-auto bg-surface-2 border border-border-ink/20",
-    // KI: links, mit Tintenstreifen am linken Rand
+    "relative max-w-[92%] sm:max-w-[85%] md:max-w-[75%] lg:max-w-[65%] xl:max-w-[60%] rounded-xl px-3 py-2 sm:px-4 sm:py-3",
+    "shadow-[0_0_0_1px_var(--border-chalk)] backdrop-blur-[0.5px] text-text-primary",
+    isUser &&
+      "ml-auto border border-[var(--border-chalk-strong)] bg-[rgba(255,255,255,0.03)] shadow-[0_0_0_1px_var(--border-chalk-strong),0_1px_0_rgba(255,255,255,0.03)]",
     isAssistant &&
-      "mr-auto bg-bg-page border border-border-ink/15 border-l-[3px] border-l-accent-primary",
-    // System: zentriert, dezent
+      "mr-auto border border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] shadow-[0_0_0_1px_var(--border-chalk),-2px_0_0_var(--accent-primary)]",
     isSystem &&
-      "mx-auto max-w-[95%] sm:max-w-2xl bg-surface-1/50 border border-border-ink/10 text-center",
+      "mx-auto max-w-[95%] sm:max-w-2xl border border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] text-center opacity-80",
   );
 
   const handleCopy = () => {
@@ -212,8 +211,8 @@ export function ChatMessage({
         {!isSystem && !isEditing && (
           <div
             className={cn(
-              "flex items-center gap-0.5 mt-2 pt-2 border-t border-border-ink/10 transition-opacity duration-150",
-              "opacity-70 group-hover:opacity-100",
+              "flex items-center gap-0.5 mt-2 pt-2 border-t border-[var(--border-chalk)] transition-opacity duration-150",
+              "opacity-80 group-hover:opacity-100",
               isUser ? "justify-end" : "justify-start",
             )}
           >
@@ -275,7 +274,7 @@ export function ChatMessage({
                 variant="secondary"
                 size="sm"
                 onClick={() => handleFollowUp(suggestion)}
-                className="text-xs bg-surface-1 border-border-ink/20 text-ink-secondary hover:text-ink-primary"
+                className="text-xs border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] text-ink-secondary hover:border-[var(--border-chalk-strong)] hover:text-ink-primary"
               >
                 {suggestion}
               </Button>

--- a/src/components/chat/ContextDropdownBar.tsx
+++ b/src/components/chat/ContextDropdownBar.tsx
@@ -131,7 +131,7 @@ function DropdownPanel({
     <div
       ref={panelRef}
       className={cn(
-        "dropdown-appear absolute z-popover w-[260px] origin-top-left rounded-[16px] border border-white/5 bg-[rgba(20,20,20,0.95)] p-3 text-[#F2F2F5] shadow-[0_8px_24px_rgba(0,0,0,0.35)] backdrop-blur",
+        "dropdown-appear absolute z-popover w-[260px] origin-top-left rounded-2xl border border-[var(--border-chalk)] bg-[rgba(19,19,20,0.96)] p-3 text-text-primary shadow-[0_18px_40px_rgba(0,0,0,0.45)] backdrop-blur",
         placement === "bottom" ? "top-full mt-2" : "bottom-full mb-2",
       )}
       style={{ maxHeight: maxHeight ? `${maxHeight}px` : undefined }}
@@ -155,13 +155,13 @@ function DropdownItem<T>({
     <button
       type="button"
       onClick={() => onSelect(option.id)}
-      className="group flex h-11 w-full items-center justify-between rounded-lg px-3 text-[14px] leading-[1.2] text-[#F2F2F5] transition-colors duration-150 hover:bg-[rgba(255,255,255,0.08)]"
+      className="group flex h-11 w-full items-center justify-between rounded-lg px-3 text-[14px] leading-[1.2] text-text-primary transition-colors duration-150 hover:bg-[rgba(255,255,255,0.05)]"
     >
       <div className="flex min-w-0 items-center gap-3 truncate">
-        {Icon ? <Icon className="h-4 w-4 text-[#A3A3AB]" /> : null}
+        {Icon ? <Icon className="h-4 w-4 text-ink-tertiary" /> : null}
         <span className="truncate">{option.label}</span>
       </div>
-      {selected ? <Check className="h-4 w-4 text-[#F2F2F5]" /> : null}
+      {selected ? <Check className="h-4 w-4 text-text-primary" /> : null}
     </button>
   );
 }
@@ -185,14 +185,14 @@ function TriggerBadge({
       ref={innerRef}
       onClick={onClick}
       className={cn(
-        "flex h-10 items-center gap-2 rounded-full border border-white/5 bg-[rgba(28,28,28,0.92)] px-3 text-[13px] font-medium text-[#F2F2F5] transition-colors duration-150 hover:bg-[rgba(255,255,255,0.05)]",
-        open && "shadow-[0_0_0_1px_rgba(111,108,255,0.35)]",
+        "flex h-9 items-center gap-2 rounded-full border border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] px-3 text-[13px] font-medium text-text-primary transition-colors duration-150 hover:border-[var(--border-chalk-strong)] hover:bg-[rgba(255,255,255,0.05)]",
+        open && "shadow-[0_0_0_1px_var(--border-chalk-strong)]",
       )}
       aria-expanded={open}
     >
-      {Icon ? <Icon className="h-4 w-4 text-[#A3A3AB]" /> : null}
+      {Icon ? <Icon className="h-4 w-4 text-ink-tertiary" /> : null}
       <span className="truncate">{label}</span>
-      <ChevronDown className="h-4 w-4 text-[#A3A3AB]" />
+      <ChevronDown className="h-4 w-4 text-ink-tertiary" />
     </button>
   );
 }

--- a/src/components/layout/AppMenuDrawer.tsx
+++ b/src/components/layout/AppMenuDrawer.tsx
@@ -129,7 +129,7 @@ export function AppMenuDrawer({
         <MaterialCard
           variant="hero"
           className={cn(
-            "h-[100dvh] w-[80vw] max-w-[320px] sm:rounded-2xl rounded-none overflow-y-auto overscroll-contain relative bg-bg-page",
+            "h-[100dvh] w-[80vw] max-w-[320px] sm:rounded-2xl rounded-none overflow-y-auto overscroll-contain relative bg-[rgba(19,19,20,0.96)] border border-[var(--border-chalk)] shadow-[0_0_0_1px_var(--border-chalk),0_18px_40px_rgba(0,0,0,0.45)]",
             "transition-transform duration-200 ease-[cubic-bezier(0.22,0.61,0.36,1)]",
             "motion-safe:animate-[slideInLeft_180ms_ease-out]",
           )}
@@ -146,12 +146,12 @@ export function AppMenuDrawer({
             className="sr-only"
           />
           {/* Header with Close Button */}
-          <div className="flex items-center justify-between sticky top-0 bg-bg-page z-10 py-3 px-4 border-b border-border-ink/10">
+          <div className="flex items-center justify-between sticky top-0 bg-[rgba(19,19,20,0.96)] z-10 py-3 px-4 border-b border-[var(--border-chalk)]">
             <BrandWordmark className="text-base" />
             <button
               onClick={onClose}
               ref={closeButtonRef}
-              className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-ink-secondary hover:text-ink-primary hover:bg-surface-2 transition-colors"
+              className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-ink-secondary hover:text-ink-primary hover:bg-[rgba(255,255,255,0.04)] transition-colors border border-transparent hover:border-[var(--border-chalk)]"
               aria-label="Menü schließen"
             >
               <X className="h-5 w-5" />
@@ -171,16 +171,16 @@ export function AppMenuDrawer({
                       to={item.path}
                       onClick={onClose}
                       className={cn(
-                        "flex items-center gap-3 px-3 py-3 rounded-lg transition-colors min-h-[48px]",
+                        "flex items-center gap-3 px-3 py-3 rounded-lg transition-colors min-h-[48px] border border-transparent",
                         isActive
-                          ? "bg-accent-primary/10 text-accent-primary"
-                          : "text-ink-primary hover:bg-surface-2",
+                          ? "border-[var(--border-chalk-strong)] bg-[rgba(255,255,255,0.04)] text-text-primary"
+                          : "text-ink-primary hover:border-[var(--border-chalk)] hover:bg-[rgba(255,255,255,0.03)]",
                       )}
                     >
                       <Icon
                         className={cn(
                           "h-5 w-5 flex-shrink-0",
-                          isActive ? "text-accent-primary" : "text-ink-secondary",
+                          isActive ? "text-text-primary" : "text-ink-secondary",
                         )}
                       />
                       <div className="flex-1 min-w-0">
@@ -200,7 +200,7 @@ export function AppMenuDrawer({
             {secondaryPages.length > 0 && (
               <>
                 {/* Divider */}
-                <hr className="my-4 border-border-ink/10" />
+                <hr className="my-4 border-[color:hsla(0,0%,92%,0.35)]" />
 
                 {/* Secondary Links */}
                 <ul className="space-y-1" role="list">
@@ -210,10 +210,10 @@ export function AppMenuDrawer({
                         to={page.path}
                         onClick={onClose}
                         className={cn(
-                          "flex items-center px-3 py-2.5 rounded-lg transition-colors text-sm min-h-[44px]",
+                          "flex items-center px-3 py-2.5 rounded-lg transition-colors text-sm min-h-[44px] border border-transparent",
                           location.pathname === page.path
-                            ? "text-accent-primary bg-accent-primary/5"
-                            : "text-ink-secondary hover:text-ink-primary hover:bg-surface-2",
+                            ? "text-text-primary border-[var(--border-chalk-strong)] bg-[rgba(255,255,255,0.04)]"
+                            : "text-ink-secondary hover:text-ink-primary hover:border-[var(--border-chalk)] hover:bg-[rgba(255,255,255,0.03)]",
                         )}
                       >
                         {page.label}

--- a/src/components/layout/BookLayout.tsx
+++ b/src/components/layout/BookLayout.tsx
@@ -23,7 +23,7 @@ export function BookLayout({
   return (
     <div className="relative flex min-h-[calc(var(--vh,1vh)*100)] w-full flex-col bg-bg-app text-ink-primary overflow-hidden">
       {/* Header / Top Edge of the Page */}
-      <header className="sticky top-0 z-header flex h-14 w-full items-center justify-between border-b border-border-ink/10 bg-bg-page/95 px-4 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md">
+      <header className="sticky top-0 z-header flex h-14 w-full items-center justify-between border-b border-[var(--border-chalk)] bg-[rgba(19,19,20,0.9)] px-4 backdrop-blur supports-[backdrop-filter]:backdrop-blur-md">
         {/* Left: Hamburger Menu */}
         <div className="flex items-center">
           <Button
@@ -31,14 +31,14 @@ export function BookLayout({
             size="icon"
             onClick={onMenuClick}
             aria-label="Hauptmenü öffnen"
-            className="text-ink-primary hover:bg-ink-primary/5"
+            className="text-ink-primary hover:bg-[rgba(255,255,255,0.04)]"
           >
             <Menu className="h-5 w-5" />
           </Button>
         </div>
         {/* Center: Title / Date */}
         <div className="absolute left-1/2 -translate-x-1/2 text-center">
-          <h1 className="text-base font-serif font-semibold tracking-tight text-ink-primary">
+          <h1 className="text-base font-serif font-semibold tracking-[0.04em] text-ink-primary">
             {title || "Disa AI"}
           </h1>
         </div>
@@ -49,10 +49,14 @@ export function BookLayout({
       {/* Main Page Content Area */}
       <main
         className={cn(
-          "flex-1 relative flex flex-col max-w-5xl mx-auto w-full shadow-sm sm:my-4 sm:border sm:border-border-ink/20 sm:rounded-xl",
+          "flex-1 relative flex flex-col max-w-5xl mx-auto w-full shadow-[0_0_0_1px_var(--border-chalk)] sm:my-4 sm:border sm:border-[var(--border-chalk)] sm:rounded-2xl",
           className,
         )}
-        style={{ background: "var(--bg-page-texture)" }}
+        style={{
+          backgroundColor: "var(--bg-page)",
+          backgroundImage: "var(--chalk-noise)",
+          backgroundBlendMode: "normal",
+        }}
       >
         {children}
 

--- a/src/components/navigation/HistorySidePanel.tsx
+++ b/src/components/navigation/HistorySidePanel.tsx
@@ -46,27 +46,27 @@ export function HistorySidePanel({
     <div className="fixed inset-0 z-drawer z-[100]" role="dialog" aria-modal="true">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/20 backdrop-blur-sm transition-opacity duration-300"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm transition-opacity duration-300"
         onClick={handleBackdropClick}
       />
 
       {/* Panel - Slide in from right */}
       <div
         className={cn(
-          "absolute right-0 top-0 h-full w-full max-w-xs sm:max-w-sm bg-bg-page shadow-2xl transition-transform duration-300 ease-out transform",
+          "absolute right-0 top-0 h-full w-full max-w-xs sm:max-w-sm bg-[rgba(19,19,20,0.96)] border-l border-[var(--border-chalk)] shadow-[0_0_0_1px_var(--border-chalk),0_18px_40px_rgba(0,0,0,0.45)] transition-transform duration-300 ease-out transform",
           isOpen ? "translate-x-0" : "translate-x-full",
         )}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border-ink/10 bg-bg-page z-10">
-          <h2 className="text-lg font-serif font-bold text-ink-primary tracking-wide">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--border-chalk)] bg-[rgba(19,19,20,0.96)] z-10">
+          <h2 className="text-lg font-serif font-bold text-ink-primary tracking-[0.04em]">
             Inhaltsverzeichnis
           </h2>
           <Button
             variant="ghost"
             size="icon"
             onClick={onClose}
-            className="text-ink-secondary hover:text-ink-primary"
+            className="text-ink-secondary hover:text-ink-primary hover:border-[var(--border-chalk)]"
           >
             <X className="h-5 w-5" />
           </Button>
@@ -79,8 +79,8 @@ export function HistorySidePanel({
             className={cn(
               "flex-1 py-3 text-sm font-medium transition-colors border-b-2",
               activeTab === "bookmarks"
-                ? "border-accent text-accent bg-accent/5"
-                : "border-transparent text-ink-secondary hover:text-ink-primary hover:bg-surface-2",
+                ? "border-[var(--border-chalk-strong)] text-text-primary bg-[rgba(255,255,255,0.04)]"
+                : "border-transparent text-ink-secondary hover:text-ink-primary hover:bg-[rgba(255,255,255,0.03)]",
             )}
           >
             <Book className="h-4 w-4 inline-block mr-2 mb-0.5" />
@@ -91,8 +91,8 @@ export function HistorySidePanel({
             className={cn(
               "flex-1 py-3 text-sm font-medium transition-colors border-b-2",
               activeTab === "archive"
-                ? "border-accent text-accent bg-accent/5"
-                : "border-transparent text-ink-secondary hover:text-ink-primary hover:bg-surface-2",
+                ? "border-[var(--border-chalk-strong)] text-text-primary bg-[rgba(255,255,255,0.04)]"
+                : "border-transparent text-ink-secondary hover:text-ink-primary hover:bg-[rgba(255,255,255,0.03)]",
             )}
           >
             <Database className="h-4 w-4 inline-block mr-2 mb-0.5" />
@@ -117,10 +117,10 @@ export function HistorySidePanel({
                 key={chat.id}
                 onClick={() => onSelect(chat.id)}
                 className={cn(
-                  "w-full text-left px-4 py-3 rounded-lg transition-all group",
-                  "hover:bg-surface-2",
+                  "w-full text-left px-4 py-3 rounded-lg transition-all group border border-[color:hsla(0,0%,92%,0.35)]",
+                  "hover:border-[var(--border-chalk-strong)] hover:bg-[rgba(255,255,255,0.03)]",
                   activeId === chat.id
-                    ? "bg-accent/5 border-l-4 border-accent pl-3"
+                    ? "bg-[rgba(255,255,255,0.05)] border-l-4 border-[var(--accent-primary)] pl-3 shadow-[0_0_0_1px_var(--border-chalk-strong)]"
                     : "border-l-4 border-transparent",
                 )}
               >
@@ -129,7 +129,7 @@ export function HistorySidePanel({
                     className={cn(
                       "font-medium truncate",
                       activeId === chat.id
-                        ? "text-accent"
+                        ? "text-text-primary"
                         : "text-ink-primary group-hover:text-ink-primary",
                     )}
                   >
@@ -150,7 +150,7 @@ export function HistorySidePanel({
         </div>
 
         {/* Footer Action */}
-        <div className="absolute bottom-0 w-full p-4 border-t border-border-ink/10 bg-bg-page">
+        <div className="absolute bottom-0 w-full p-4 border-t border-[var(--border-chalk)] bg-[rgba(19,19,20,0.96)]">
           <Button
             variant="primary"
             className="w-full shadow-md"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -41,11 +41,13 @@ body {
   overflow-x: hidden;
   position: relative;
   overscroll-behavior: none;
-  background: radial-gradient(120% 140% at 10% 20%, rgba(143, 123, 255, 0.08), transparent 55%),
-    radial-gradient(120% 140% at 90% 10%, rgba(94, 228, 255, 0.08), transparent 55%),
-    var(--surface-base);
-  color: var(--color-text-primary, var(--fg0));
-  font-family: var(--font-family-sans);
+  background-color: var(--bg-app);
+  background-image: var(--chalk-noise);
+  background-blend-mode: normal;
+  color: var(--text-primary);
+  font-family: var(--font-sans, "Inter", system-ui, sans-serif);
+  letter-spacing: 0.01em;
+  -webkit-font-smoothing: antialiased;
   padding-top: var(--mobile-safe-top);
   padding-bottom: calc(var(--mobile-gutter) + var(--mobile-safe-bottom));
   padding-left: calc(var(--mobile-gutter) + var(--mobile-safe-left));

--- a/src/styles/design-tokens.generated.ts
+++ b/src/styles/design-tokens.generated.ts
@@ -247,5 +247,5 @@ export const preCalculatedTokens: Record<"light" | "dark", CssVariableMap> = {
 } as const;
 
 // Performance: Pre-calculated tokens eliminate ~4ms runtime calculation per theme switch
-// Generated: 2025-12-03T18:58:48.077Z
+// Generated: 2025-12-03T19:31:41.596Z
 // Tokens: 117 variables per theme

--- a/src/styles/theme-ink.css
+++ b/src/styles/theme-ink.css
@@ -1,138 +1,115 @@
 /**
- * DISA AI - INK ON PAPER THEME
+ * DISA AI - SCHIEFER & KREIDE THEME
  *
- * Concept: "Tinte auf Papier" - Calm book aesthetic
- *
- * Colors:
- * - Off-white paper backgrounds
- * - Dark ink text
- * - Muted indigo accents
+ * Konzept: Matte Schieferoberfläche mit digitaler Kreide.
+ * Ruhig, analog, warm und klar.
  */
 
 :root {
   /* ========================================
-   * COLOR PALETTE
+   * COLOR PALETTE (Schiefer)
    * ======================================== */
 
-  /* Paper Backgrounds */
-  --bg-app: hsl(45, 25%, 96%); /* App background - Warm off-white */
-  --bg-page: hsl(45, 20%, 98%); /* Page/Chat background - Slightly lighter */
-  --bg-surface: hsl(45, 20%, 98%); /* For cards/surfaces */
+  /* Slate Backgrounds */
+  --bg-app: hsl(240, 4%, 6%); /* #0E0E0F - matte schwarzer Schiefer */
+  --bg-page: hsl(240, 3%, 8%); /* #131314 - leicht heller Schiefer */
+  --bg-surface: hsl(240, 3%, 11%); /* abgesetzte Flächen */
+  --bg-surface-strong: hsl(240, 3%, 13%);
 
-  /* Ink Colors */
-  --ink-primary: hsl(220, 15%, 18%); /* Dark Blue-Black */
-  --ink-secondary: hsl(220, 10%, 50%); /* Muted Grey */
-  --ink-tertiary: hsl(220, 10%, 55%); /* Light Grey - Timestamps, Hints (boosted contrast) */
-  --ink-on-accent: hsl(45, 20%, 98%); /* Light text on accent */
+  /* Chalk Text */
+  --ink-primary: hsl(0, 0%, 92%); /* #ECECEC */
+  --ink-secondary: hsl(0, 0%, 62%); /* #9E9E9E */
+  --ink-tertiary: hsl(0, 0%, 55%);
+  --ink-on-accent: hsl(240, 6%, 7%);
 
-  /* Accent Colors */
-  --accent-primary: hsl(260, 35%, 45%); /* Muted Indigo/Violet */
-  --accent-secondary: hsl(260, 25%, 65%); /* Lighter Violet */
-  --accent-hover: hsl(260, 40%, 40%);
+  /* Chalk Accents */
+  --accent-primary: hsl(218, 100%, 82%); /* #A7C8FF - Kreideblau */
+  --accent-secondary: hsl(49, 100%, 83%); /* #FFEFA6 - Kreidegelb */
+  --accent-tertiary: hsl(350, 100%, 89%); /* #FFCAD4 - Kreidepink */
+  --accent-hover: hsl(218, 90%, 78%);
 
-  /* Semantic Colors */
-  --color-success: hsl(140, 40%, 45%);
-  --color-warning: hsl(35, 80%, 50%);
-  --color-error: hsl(0, 60%, 45%);
+  /* Semantic Colors aligned to chalk warmth */
+  --color-success: hsl(147, 42%, 68%);
+  --color-warning: var(--accent-secondary);
+  --color-error: hsl(0, 62%, 65%);
 
   /* Mapping to existing variable names for compatibility */
   --bg-base: var(--bg-app);
   --bg-0: var(--bg-app);
   --bg-1: var(--bg-page);
-  --bg-2: var(--bg-page);
+  --bg-2: var(--bg-surface);
 
   --surface-1: var(--bg-page);
-  --surface-2: var(--bg-page); /* No elevation distinction by color, use shadow */
-  --surface-3: hsl(45, 15%, 92%); /* Hover state */
-  --surface-inset: hsl(45, 10%, 94%);
+  --surface-2: var(--bg-surface);
+  --surface-3: var(--bg-surface-strong);
+  --surface-inset: hsl(240, 4%, 9%);
 
   --text-primary: var(--ink-primary);
   --text-secondary: var(--ink-secondary);
   --text-muted: var(--ink-secondary);
-  --text-disabled: hsl(220, 10%, 65%);
+  --text-disabled: hsla(0, 0%, 62%, 0.6);
   --text-on-accent: var(--ink-on-accent);
 
   --accent: var(--accent-primary);
   --brand: var(--accent-primary);
 
   /* ========================================
-   * SHADOWS & BORDERS
+   * SHADOWS & BORDERS (digitale Kreide)
    * ======================================== */
 
-  /* Subtle Paper Shadows */
-  --shadow-paper: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-floating: 0 4px 12px rgba(0, 0, 0, 0.12);
+  --shadow-paper: 0 1px 2px rgba(0, 0, 0, 0.28);
+  --shadow-floating: 0 8px 24px rgba(0, 0, 0, 0.32);
 
-  /* Map to existing names */
   --shadow-sm: var(--shadow-paper);
   --shadow-md: var(--shadow-floating);
   --shadow-soft-raise: var(--shadow-paper);
   --shadow-strong-raise: var(--shadow-floating);
-  --shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.02);
 
-  /* Legacy mappings for component compatibility */
+  /* Keep legacy tokens but remove neon glows */
   --shadow-raise: var(--shadow-paper);
   --shadow-raiseLg: var(--shadow-floating);
-
-  /* Glow effects for brand and accent colors */
-  --shadow-brandGlow: 0 0 20px hsla(260, 35%, 45%, 0.25);
-  --shadow-brandGlowLg: 0 0 32px hsla(260, 35%, 45%, 0.3);
-  --shadow-accentGlow: 0 0 20px hsla(260, 35%, 45%, 0.25);
-  --shadow-accentGlowLg: 0 0 32px hsla(260, 35%, 45%, 0.3);
+  --shadow-brandGlow: 0 0 0 rgba(0, 0, 0, 0);
+  --shadow-brandGlowLg: 0 0 0 rgba(0, 0, 0, 0);
+  --shadow-accentGlow: 0 0 0 rgba(0, 0, 0, 0);
+  --shadow-accentGlowLg: 0 0 0 rgba(0, 0, 0, 0);
 
   /* Borders */
-  --border-color: hsl(45, 10%, 90%);
+  --border-color: hsl(240, 4%, 16%);
+  --border-chalk: hsla(0, 0%, 92%, 0.28);
+  --border-chalk-strong: hsla(0, 0%, 92%, 0.5);
   --border-width: 1px;
 
   /* Radius */
-  --r-sm: 8px;
-  --r-md: 12px;
-  --r-lg: 16px;
+  --r-sm: 10px;
+  --r-md: 14px;
+  --r-lg: 18px;
 
   /* ========================================
    * TYPOGRAPHY
    * ======================================== */
 
-  --font-sans: system-ui, -apple-system, sans-serif; /* Clean Sans */
-
-  --text-base: 17px; /* Mobile legible */
+  --font-sans: "Inter", "IBM Plex Sans", "Cabin", system-ui, -apple-system, sans-serif;
+  --text-base: 17px;
   --leading-normal: 1.6;
-  --font-serif: Lora, serif;
-}
+  --font-serif: "Inter", system-ui, sans-serif;
 
-:root {
-  --bg-page-texture: var(--bg-page) var(--noise-texture-light);
+  /* ========================================
+   * TEXTURES
+   * ======================================== */
+  --chalk-noise: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.035) 0%, transparent 32%),
+    radial-gradient(circle at 75% 30%, rgba(255, 255, 255, 0.028) 0%, transparent 26%),
+    radial-gradient(circle at 40% 70%, rgba(255, 255, 255, 0.02) 0%, transparent 28%);
+
+  --bg-page-texture: var(--bg-page);
 }
 
 :root[data-theme="dark"] {
-  --bg-page-texture: var(--bg-page) var(--noise-texture-dark);
-}
+  /* Stay on slate palette in dark mode */
+  --bg-app: hsl(240, 4%, 6%);
+  --bg-page: hsl(240, 3%, 8%);
+  --bg-surface: hsl(240, 3%, 11%);
+  --bg-surface-strong: hsl(240, 3%, 13%);
 
-/* Dark Mode Overrides - "Slate & Chalk" Metaphor */
-:root[data-theme="dark"] {
-  /* Slate Backgrounds */
-  --bg-app: hsl(220, 20%, 14%); /* Deep Slate */
-  --bg-page: hsl(220, 18%, 18%); /* Slightly lighter Slate Page */
-  --bg-surface: hsl(220, 18%, 20%); /* Cards */
-
-  /* Chalk Text */
-  --ink-primary: hsl(40, 10%, 92%); /* Chalk White */
-  --ink-secondary: hsl(220, 15%, 70%); /* Muted Chalk */
-  --ink-tertiary: hsl(220, 15%, 55%);
-
-  /* Bioluminescent Accents */
-  --accent-primary: hsl(260, 60%, 70%); /* Glowing Violet */
-  --accent-secondary: hsl(260, 40%, 50%);
-  --accent-hover: hsl(260, 70%, 75%);
-
-  --border-color: hsl(220, 15%, 25%);
-
-  --shadow-paper: 0 1px 3px rgba(0, 0, 0, 0.4);
-  --shadow-floating: 0 8px 24px rgba(0, 0, 0, 0.5);
-
-  /* Dark mode glow effects */
-  --shadow-brandGlow: 0 0 20px hsla(260, 60%, 70%, 0.2);
-  --shadow-brandGlowLg: 0 0 32px hsla(260, 60%, 70%, 0.3);
-  --shadow-accentGlow: 0 0 20px hsla(260, 60%, 70%, 0.2);
-  --shadow-accentGlowLg: 0 0 32px hsla(260, 60%, 70%, 0.3);
+  --bg-page-texture: var(--bg-page);
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -10,21 +10,22 @@ import { cn } from "@/lib/utils";
  * Focuses on clarity, touch targets (min 44px), and subtle paper interactions.
  */
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/70 disabled:opacity-50 disabled:pointer-events-none cursor-pointer",
+  "inline-flex items-center justify-center rounded-full text-sm font-semibold tracking-[0.01em] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-[var(--border-chalk-strong)] disabled:opacity-50 disabled:pointer-events-none cursor-pointer",
   {
     variants: {
       variant: {
         primary:
-          "bg-accent-primary text-surface-1 shadow-sm hover:bg-accent-hover active:translate-y-[1px]",
+          "border border-[var(--border-chalk-strong)] bg-[rgba(236,236,236,0.04)] text-text-primary shadow-[0_0_0_1px_rgba(236,236,236,0.08)] hover:bg-[rgba(236,236,236,0.07)] active:translate-y-[0.5px]",
         secondary:
-          "bg-surface-2 text-text-primary border border-border-ink shadow-sm hover:bg-surface-3 hover:shadow-md active:translate-y-[1px]",
-        ghost: "hover:bg-surface-2 text-text-secondary hover:text-text-primary active:bg-surface-3",
+          "border border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] text-text-primary shadow-[0_0_0_1px_rgba(236,236,236,0.05)] hover:border-[var(--border-chalk-strong)] hover:bg-[rgba(255,255,255,0.03)] active:translate-y-[0.5px]",
+        ghost:
+          "text-text-secondary hover:text-text-primary border border-transparent hover:border-[var(--border-chalk)] hover:bg-[rgba(255,255,255,0.03)] active:bg-[rgba(255,255,255,0.05)]",
         link: "text-accent underline-offset-4 hover:underline p-0 h-auto min-h-0",
       },
       size: {
-        default: "min-h-[44px] py-2 px-4",
-        sm: "min-h-[44px] px-3 text-xs",
-        lg: "min-h-[56px] px-8 text-base",
+        default: "min-h-[44px] min-w-[44px] py-2 px-4",
+        sm: "min-h-[42px] min-w-[42px] px-3 text-xs",
+        lg: "min-h-[52px] min-w-[52px] px-6 text-base",
         icon: "min-h-[44px] min-w-[44px] p-2",
       },
     },

--- a/src/ui/ChatStartCard.tsx
+++ b/src/ui/ChatStartCard.tsx
@@ -18,24 +18,24 @@ interface ChatStartCardProps {
 
 export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCardProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-border-ink/30 bg-surface-2 px-6 py-8 text-center shadow-sm">
-      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-accent-primary/10 text-accent-primary">
+    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-[var(--border-chalk-strong)] bg-[rgba(255,255,255,0.02)] px-6 py-8 text-center shadow-[0_0_0_1px_var(--border-chalk)]">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full border border-[var(--border-chalk-strong)] bg-[rgba(255,255,255,0.03)] text-accent-primary shadow-[0_0_0_1px_var(--border-chalk)]">
         <Sparkles className="h-6 w-6" />
       </div>
 
       <BrandWordmark className="text-2xl sm:text-3xl" state="idle" />
 
-      <p className="max-w-xl text-sm leading-relaxed text-text-secondary">
-        Starte ein neues Gespräch oder setze eine Unterhaltung fort. Schlanke Eingabeleiste, klare
-        Kontraste und fokussierte Aktionen sorgen für Ruhe im Flow.
+      <p className="max-w-xl text-sm leading-relaxed text-text-secondary tracking-[0.01em]">
+        Starte ein neues Gespräch oder setze eine Unterhaltung fort. Kreideweiße Linien auf mattem
+        Schiefer halten den Fokus auf deinen Gedanken.
       </p>
 
       <div className="flex w-full max-w-md flex-col gap-3 sm:flex-row">
         <button
           onClick={onNewChat}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/60"
+          className="flex w-full items-center justify-center gap-2 rounded-full border border-[var(--border-chalk-strong)] bg-[rgba(236,236,236,0.05)] px-5 py-3 text-sm font-semibold text-text-primary shadow-[0_0_0_1px_var(--border-chalk-strong)] transition hover:bg-[rgba(236,236,236,0.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-chalk-strong)]"
         >
-          <Sparkles className="h-4 w-4" />
+          <Sparkles className="h-4 w-4 text-accent-primary" />
           Neues Gespräch
         </button>
 
@@ -46,7 +46,7 @@ export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCar
               variant: "secondary",
               size: "default",
               className:
-                "flex w-full items-center justify-center gap-2 border-border-ink/40 bg-surface-1 text-text-primary",
+                "flex w-full items-center justify-center gap-2 border-[var(--border-chalk)] bg-[rgba(255,255,255,0.02)] text-text-primary",
             })}
           >
             <History className="h-4 w-4" />

--- a/src/ui/__tests__/Button.test.tsx
+++ b/src/ui/__tests__/Button.test.tsx
@@ -13,14 +13,14 @@ describe("Button", () => {
   it("applies primary variant classes", () => {
     render(<Button variant="primary">Primary</Button>);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("bg-accent-primary");
-    expect(button.className).toContain("text-surface-1");
+    expect(button.className).toContain("border-[var(--border-chalk-strong)]");
+    expect(button.className).toContain("bg-[rgba(236,236,236,0.04)]");
   });
 
   it("applies secondary variant classes", () => {
     render(<Button variant="secondary">Secondary</Button>);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("bg-surface-2");
-    expect(button.className).toContain("border-border-ink");
+    expect(button.className).toContain("border-[var(--border-chalk)]");
+    expect(button.className).toContain("bg-[rgba(255,255,255,0.02)]");
   });
 });


### PR DESCRIPTION
## Summary
- switch the app theme to the slate-and-chalk palette with matte noise background
- restyle chat bubbles, dropdown chips, menus, and start card to thin chalk outlines and minimal padding
- update button styles and tests to reflect the new circular chalk controls

## Testing
- npm run verify
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308d1a20e08320abdcad061f8cc009)