### PR TITLE
Fix dropdown alignment and model catalog loading

### DIFF
--- a/src/components/chat/UnifiedInputBar.tsx
+++ b/src/components/chat/UnifiedInputBar.tsx
@@ -86,6 +86,7 @@ function DropdownPanel({
   children: ReactNode;
   onClose: () => void;
 }) {
+  const PANEL_WIDTH = 260;
   const panelRef = useRef<HTMLDivElement>(null);
   const [placement, setPlacement] = useState<"bottom" | "top">("bottom");
   const [maxHeight, setMaxHeight] = useState<number | undefined>();
@@ -104,6 +105,8 @@ function DropdownPanel({
 
       const rect = anchor.getBoundingClientRect();
       const viewportHeight = window.innerHeight;
+      const viewportWidth = window.innerWidth;
+      const horizontalPadding = 12;
       const spaceBelow = viewportHeight - rect.bottom - 12;
       const spaceAbove = rect.top - 12;
       const shouldPlaceBottom = spaceBelow >= spaceAbove;
@@ -111,16 +114,21 @@ function DropdownPanel({
       const availableSpace = shouldPlaceBottom ? spaceBelow : spaceAbove;
       setMaxHeight(Math.max(0, Math.min(availableSpace, 320)));
 
+      const clampedLeft = Math.min(
+        Math.max(rect.left, horizontalPadding),
+        Math.max(horizontalPadding, viewportWidth - PANEL_WIDTH - horizontalPadding),
+      );
+
       // Calculate fixed position
       if (shouldPlaceBottom) {
         setPosition({
           top: rect.bottom + 8,
-          left: rect.left,
+          left: clampedLeft,
         });
       } else {
         setPosition({
           bottom: viewportHeight - rect.top + 8,
-          left: rect.left,
+          left: clampedLeft,
         });
       }
     };

--- a/src/contexts/ModelCatalogContext.tsx
+++ b/src/contexts/ModelCatalogContext.tsx
@@ -17,9 +17,11 @@ export function ModelCatalogProvider({ children }: { children: React.ReactNode }
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const hasRequestedRef = useRef(false);
+  const isRefreshingRef = useRef(false);
 
   const refresh = useCallback(async () => {
-    if (loading) return;
+    if (isRefreshingRef.current) return;
+    isRefreshingRef.current = true;
     hasRequestedRef.current = true;
     setLoading(true);
     setError(null);
@@ -34,9 +36,10 @@ export function ModelCatalogProvider({ children }: { children: React.ReactNode }
       console.error("Model catalog loading failed", err);
       setError("Modelle konnten nicht geladen werden.");
     } finally {
+      isRefreshingRef.current = false;
       setLoading(false);
     }
-  }, [loading]);
+  }, []);
 
   useEffect(() => {
     if (hasRequestedRef.current) return;


### PR DESCRIPTION
## Summary
- prevent the model catalog refresh from being skipped and stuck in a loading state
- clamp dropdown positioning so role/model menus stay within the viewport on narrow screens

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e4ad23cc83208038ad011d757aef)