### PR TITLE
Enhance chat hero layering and input accents

### DIFF
--- a/src/components/chat/UnifiedInputBar.tsx
+++ b/src/components/chat/UnifiedInputBar.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { DEFAULT_MODEL_ID } from "@/config/modelPresets";
 import type { ModelEntry } from "@/config/models";
 import { useRoles } from "@/contexts/RolesContext";
 import type { UIRole } from "@/data/roles";
@@ -269,6 +270,13 @@ export function UnifiedInputBar({
     }
   };
 
+  const hasActiveRole = activeRole !== null;
+  const hasCustomStyle = settings.discussionPreset !== "locker_neugierig";
+  const hasCustomCreativity = (settings.creativity ?? 45) !== 45;
+  const hasCustomModel = Boolean(
+    settings.preferredModelId && settings.preferredModelId !== DEFAULT_MODEL_ID,
+  );
+
   return (
     <div
       ref={containerRef}
@@ -279,9 +287,9 @@ export function UnifiedInputBar({
       }}
     >
       {/* Unified Chat Bar Container */}
-      <div className="rounded-2xl border border-[var(--border-chalk)] bg-[rgba(19,19,20,0.90)] backdrop-blur-md shadow-[0_4px_16px_rgba(0,0,0,0.3)] p-2.5">
+      <div className="rounded-2xl border border-[var(--border-chalk-strong)] bg-[rgba(16,18,22,0.92)] backdrop-blur-lg shadow-[0_16px_38px_rgba(0,0,0,0.42)] ring-1 ring-[rgba(243,214,138,0.06)] p-3">
         {/* Input Row */}
-        <div className="flex items-end gap-2.5 mb-2.5">
+        <div className="flex items-end gap-2.5 mb-3">
           <div className="relative flex-1">
             <Textarea
               ref={textareaRef}
@@ -290,7 +298,7 @@ export function UnifiedInputBar({
               onKeyDown={handleKeyDown}
               placeholder="Formuliere deine Frage…"
               aria-label="Nachricht eingeben"
-              className="input-chalk w-full min-h-[36px] max-h-[160px] resize-none px-2.5 py-1.5 placeholder:text-chalk-dim/50 text-[14px]"
+              className="input-chalk w-full min-h-[40px] max-h-[160px] resize-none rounded-xl bg-[rgba(255,255,255,0.02)] px-3 py-2 text-[14px] shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] placeholder:text-chalk-dim/60"
               rows={1}
               data-testid="composer-input"
             />
@@ -301,7 +309,7 @@ export function UnifiedInputBar({
               onClick={onSend}
               disabled={!value.trim() || isLoading}
               className={cn(
-                "btn-chalk h-9 w-9 flex items-center justify-center",
+                "h-10 w-10 flex items-center justify-center rounded-xl border border-[color-mix(in_srgb,var(--accent-primary)_60%,transparent)] bg-[var(--accent-primary)] text-[var(--ink-on-accent)] shadow-[0_12px_28px_rgba(243,214,138,0.35)] transition hover:translate-y-[-1px] hover:shadow-[0_16px_36px_rgba(243,214,138,0.4)]",
                 !value.trim() && "opacity-50 cursor-not-allowed",
               )}
               aria-label="Senden"
@@ -320,12 +328,18 @@ export function UnifiedInputBar({
               onClick={() => toggleDropdown("role")}
               ref={triggerRefs.role}
               className={cn(
-                "h-7 px-2 flex items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] text-[12px] text-chalk-dim transition-all duration-150",
-                "hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.06)]",
-                openDropdown === "role" &&
-                  "border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)]",
+                "h-8 px-2.5 flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.14)] bg-[rgba(18,20,24,0.82)] text-[12px] text-chalk-dim/90 shadow-[0_8px_18px_rgba(0,0,0,0.32)] backdrop-blur-sm transition-all duration-150",
+                "hover:border-[color-mix(in_srgb,var(--accent-primary)_30%,transparent)] hover:bg-[rgba(24,26,32,0.95)]",
+                (openDropdown === "role" || hasActiveRole) &&
+                  "border-[color-mix(in_srgb,var(--accent-primary)_65%,transparent)] text-text-primary shadow-[0_10px_26px_rgba(243,214,138,0.28)]",
               )}
             >
+              {hasActiveRole ? (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-[var(--accent-primary)] shadow-[0_0_0_4px_rgba(243,214,138,0.18)]"
+                  aria-hidden
+                />
+              ) : null}
               <User className="h-3.5 w-3.5 stroke-[1.5]" />
               <span className="whitespace-nowrap">Rolle</span>
               <ChevronDown className="h-3 w-3 stroke-[1.5] text-ink-tertiary" />
@@ -385,12 +399,18 @@ export function UnifiedInputBar({
               onClick={() => toggleDropdown("style")}
               ref={triggerRefs.style}
               className={cn(
-                "h-7 px-2 flex items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] text-[12px] text-chalk-dim transition-all duration-150",
-                "hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.06)]",
-                openDropdown === "style" &&
-                  "border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)]",
+                "h-8 px-2.5 flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.14)] bg-[rgba(18,20,24,0.82)] text-[12px] text-chalk-dim/90 shadow-[0_8px_18px_rgba(0,0,0,0.32)] backdrop-blur-sm transition-all duration-150",
+                "hover:border-[color-mix(in_srgb,var(--accent-primary)_30%,transparent)] hover:bg-[rgba(24,26,32,0.95)]",
+                (openDropdown === "style" || hasCustomStyle) &&
+                  "border-[color-mix(in_srgb,var(--accent-primary)_65%,transparent)] text-text-primary shadow-[0_10px_26px_rgba(243,214,138,0.28)]",
               )}
             >
+              {hasCustomStyle ? (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-[var(--accent-primary)] shadow-[0_0_0_4px_rgba(243,214,138,0.18)]"
+                  aria-hidden
+                />
+              ) : null}
               <Feather className="h-3.5 w-3.5 stroke-[1.5]" />
               <span className="whitespace-nowrap">Stil</span>
               <ChevronDown className="h-3 w-3 stroke-[1.5] text-ink-tertiary" />
@@ -425,12 +445,18 @@ export function UnifiedInputBar({
               onClick={() => toggleDropdown("creativity")}
               ref={triggerRefs.creativity}
               className={cn(
-                "h-7 px-2 flex items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] text-[12px] text-chalk-dim transition-all duration-150",
-                "hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.06)]",
-                openDropdown === "creativity" &&
-                  "border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)]",
+                "h-8 px-2.5 flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.14)] bg-[rgba(18,20,24,0.82)] text-[12px] text-chalk-dim/90 shadow-[0_8px_18px_rgba(0,0,0,0.32)] backdrop-blur-sm transition-all duration-150",
+                "hover:border-[color-mix(in_srgb,var(--accent-primary)_30%,transparent)] hover:bg-[rgba(24,26,32,0.95)]",
+                (openDropdown === "creativity" || hasCustomCreativity) &&
+                  "border-[color-mix(in_srgb,var(--accent-primary)_65%,transparent)] text-text-primary shadow-[0_10px_26px_rgba(243,214,138,0.28)]",
               )}
             >
+              {hasCustomCreativity ? (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-[var(--accent-primary)] shadow-[0_0_0_4px_rgba(243,214,138,0.18)]"
+                  aria-hidden
+                />
+              ) : null}
               <Brain className="h-3.5 w-3.5 stroke-[1.5]" />
               <span className="whitespace-nowrap">Kreativ</span>
               <ChevronDown className="h-3 w-3 stroke-[1.5] text-ink-tertiary" />
@@ -464,12 +490,18 @@ export function UnifiedInputBar({
               onClick={() => toggleDropdown("model")}
               ref={triggerRefs.model}
               className={cn(
-                "h-7 px-2 flex items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] text-[12px] text-chalk-dim transition-all duration-150",
-                "hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.06)]",
-                openDropdown === "model" &&
-                  "border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)]",
+                "h-8 px-2.5 flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.14)] bg-[rgba(18,20,24,0.82)] text-[12px] text-chalk-dim/90 shadow-[0_8px_18px_rgba(0,0,0,0.32)] backdrop-blur-sm transition-all duration-150",
+                "hover:border-[color-mix(in_srgb,var(--accent-primary)_30%,transparent)] hover:bg-[rgba(24,26,32,0.95)]",
+                (openDropdown === "model" || hasCustomModel) &&
+                  "border-[color-mix(in_srgb,var(--accent-primary)_65%,transparent)] text-text-primary shadow-[0_10px_26px_rgba(243,214,138,0.28)]",
               )}
             >
+              {hasCustomModel ? (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-[var(--accent-primary)] shadow-[0_0_0_4px_rgba(243,214,138,0.18)]"
+                  aria-hidden
+                />
+              ) : null}
               <Cpu className="h-3.5 w-3.5 stroke-[1.5]" />
               <span className="whitespace-nowrap">Modell</span>
               <ChevronDown className="h-3 w-3 stroke-[1.5] text-ink-tertiary" />

--- a/src/styles/chalkboard-theme.css
+++ b/src/styles/chalkboard-theme.css
@@ -7,15 +7,18 @@
 
 :root {
   /* Tafel-Hintergrund */
-  --chalkboard-bg: var(--bg-app, #0b0c0d);
+  --chalkboard-bg: var(--bg-app, #050608);
   --chalkboard-vignette: radial-gradient(
     ellipse at center,
-    rgba(26, 26, 28, 0.18) 0%,
-    rgba(10, 10, 11, 0.55) 100%
+    rgba(20, 23, 27, 0.25) 0%,
+    rgba(6, 8, 10, 0.75) 100%
   );
+  --chalkboard-rings: radial-gradient(circle at 30% 40%, rgba(243, 214, 138, 0.04) 0, transparent 34%),
+    radial-gradient(circle at 70% 65%, rgba(125, 220, 211, 0.035) 0, transparent 38%),
+    radial-gradient(circle at 48% 52%, rgba(255, 255, 255, 0.018) 0, transparent 50%);
 
   /* Tafel-Textur */
-  --chalkboard-texture: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"><filter id="chalkboard"><feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="3" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0.08"/><feComponentTransfer><feFuncA type="linear" slope="0.22"/></feComponentTransfer></filter><rect width="400" height="400" filter="url(%23chalkboard)" opacity="0.28"/></svg>');
+  --chalkboard-texture: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"><filter id="chalkboard"><feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="3" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0.08"/><feComponentTransfer><feFuncA type="linear" slope="0.18"/></feComponentTransfer></filter><rect width="400" height="400" filter="url(%23chalkboard)" opacity="0.24"/></svg>');
 
   /* Kreide-Effekte */
   --chalk-stroke: 1px;
@@ -29,22 +32,23 @@
   --chalk-yellow: rgba(255, 239, 166, 0.9);
 
   /* Kreide-Schatten und Glühen */
-  --chalk-glow-text: 0 0 1.5px rgba(236, 236, 236, 0.28), 0 0 1px rgba(236, 236, 236, 0.36);
-  --chalk-glow-strong: 0 0 4px rgba(236, 236, 236, 0.32), 0 0 2px rgba(236, 236, 236, 0.4);
+  --chalk-glow-text: 0 0 2px rgba(243, 214, 138, 0.28), 0 0 1px rgba(236, 236, 236, 0.36);
+  --chalk-glow-strong: 0 6px 30px rgba(0, 0, 0, 0.42), 0 0 6px rgba(243, 214, 138, 0.22);
   --chalk-shadow: 0 10px 28px rgba(0, 0, 0, 0.32);
 }
 
 /* Tafel-Hintergrund für die gesamte Chat-Seite */
 .chalkboard-container {
   background-color: var(--chalkboard-bg);
-  background-image: var(--chalkboard-texture), var(--chalk-noise), var(--chalkboard-vignette);
-  background-blend-mode: soft-light, overlay, multiply;
-  background-size: 320px 320px, 100% 100%, 100% 100%;
-  background-position: 0 0, center;
-  background-attachment: fixed, scroll, scroll;
+  background-image: var(--chalkboard-texture), var(--chalk-noise), var(--chalkboard-rings), var(--chalkboard-vignette);
+  background-blend-mode: soft-light, overlay, screen, multiply;
+  background-size: 320px 320px, 100% 100%, 260% 260%, 100% 100%;
+  background-position: 0 0, center, 50% 50%, center;
+  background-attachment: fixed, scroll, fixed, scroll;
   min-height: calc(var(--vh, 1vh) * 100);
   position: relative;
   isolation: isolate;
+  overflow: hidden;
 }
 
 /* Vignette-Effekt für den Rand */
@@ -60,6 +64,23 @@
   );
   pointer-events: none;
   z-index: 1;
+}
+
+.chalkboard-container::after {
+  content: "";
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(
+    circle at 48% 52%,
+    rgba(243, 214, 138, 0.04) 0,
+    transparent 45%
+  );
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  filter: blur(10px);
+  animation: chalk-drift 38s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
 }
 
 /* Chat-Blasen im Kreidestil */
@@ -241,5 +262,20 @@
 
   .chalk-bubble {
     border-radius: 10px;
+  }
+}
+
+@keyframes chalk-drift {
+  0% {
+    transform: translate3d(-4%, -2%, 0) scale(1);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translate3d(6%, 5%, 0) scale(1.05);
+    opacity: 0.7;
+  }
+  100% {
+    transform: translate3d(-4%, -2%, 0) scale(1);
+    opacity: 0.55;
   }
 }

--- a/src/styles/theme-ink.css
+++ b/src/styles/theme-ink.css
@@ -11,12 +11,12 @@
    * ======================================== */
 
   /* Slate Backgrounds */
-  --bg-app: #0e0e0f; /* Mattschwarzer Schiefer */
-  --bg-slate: #131314; /* Leicht heller, mit Textur */
+  --bg-app: #050608; /* Tiefes Nachtschiefer, deutlich dunklerer Grundton */
+  --bg-slate: #0b0d10; /* Abgesetzte Schieferfläche mit leichter Tönung */
 
   --bg-page: var(--bg-slate); /* Mapping for compatibility */
-  --bg-surface: #1a1a1c; /* Slightly lighter for surfaces */
-  --bg-surface-strong: #222225;
+  --bg-surface: #121418; /* Helle Tafelstufe für Karten */
+  --bg-surface-strong: #1a1d22;
 
   /* Chalk Text */
   --ink-primary: #ececec; /* text-chalk */
@@ -25,10 +25,10 @@
   --ink-on-accent: #0e0e0f;
 
   /* Chalk Accents */
-  --accent-primary: #a7c8ff; /* accent-chalk-blue */
-  --accent-secondary: #ffefa6; /* accent-yellow */
-  --accent-tertiary: #ffcad4; /* accent-pink */
-  --accent-hover: #8ab4ff;
+  --accent-primary: #f3d68a; /* Warmes Kreide-Gelb als Signalfarbe */
+  --accent-secondary: #7ddcd3; /* Gedämpftes Türkis für zarte Marker */
+  --accent-tertiary: #ffcab8; /* Sanftes Kreide-Pink als Reserve */
+  --accent-hover: #ffe199;
 
   /* Semantic Colors aligned to chalk warmth */
   --color-success: #a5d6a7;
@@ -67,9 +67,9 @@
   --shadow-md: var(--shadow-floating);
 
   /* Borders - Chalk Lines */
-  --border-color: rgba(236, 236, 236, 0.12);
-  --border-chalk: rgba(236, 236, 236, 0.24);
-  --border-chalk-strong: rgba(236, 236, 236, 0.45);
+  --border-color: rgba(236, 236, 236, 0.18);
+  --border-chalk: rgba(236, 236, 236, 0.32);
+  --border-chalk-strong: rgba(236, 236, 236, 0.55);
   --border-width: 1px;
 
   /* Radius */

--- a/src/ui/ChatStartCard.tsx
+++ b/src/ui/ChatStartCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
 import { BrandWordmark } from "../app/components/BrandWordmark";
-import { History, Sparkles } from "../lib/icons";
+import { History, Plus, Sparkles } from "../lib/icons";
 import { buttonVariants } from "./Button";
 
 /**
@@ -19,30 +19,37 @@ interface ChatStartCardProps {
 export function ChatStartCard({ onNewChat, conversationCount = 0 }: ChatStartCardProps) {
   return (
     <div
-      className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-[var(--border-chalk-blur)] bg-[rgba(255,255,255,0.02)] px-4 py-5 text-center shadow-[var(--chalk-line-shadow)] relative overflow-hidden"
+      className="relative flex flex-col items-center justify-center gap-3 overflow-hidden rounded-2xl border border-[var(--border-chalk-strong)] bg-[radial-gradient(circle_at_50%_20%,rgba(243,214,138,0.06),transparent_48%),var(--bg-surface)] px-4 py-6 text-center shadow-[0_20px_50px_rgba(0,0,0,0.55),0_0_0_1px_var(--border-chalk)]"
       style={{
         backgroundImage: "var(--chalk-noise)",
         backgroundBlendMode: "overlay",
-        boxShadow: "0 0 0 1px var(--border-chalk-blur), var(--chalk-line-shadow)",
+        boxShadow:
+          "0 14px 44px rgba(0,0,0,0.6), 0 0 0 1px var(--border-chalk-strong), inset 0 1px 0 rgba(255,255,255,0.03)",
       }}
     >
-      <div className="flex h-11 w-11 items-center justify-center rounded-full border border-[var(--border-chalk-blur)] bg-[rgba(255,255,255,0.03)] text-accent-primary shadow-[var(--chalk-glow)]">
+      <div className="relative flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border-chalk-strong)] bg-[rgba(243,214,138,0.08)] text-accent-primary shadow-[0_10px_30px_rgba(243,214,138,0.28)]">
         <Sparkles className="h-5 w-5 drop-shadow-[var(--chalk-glow)]" />
+        <span
+          className="absolute -right-1 -top-1 inline-flex h-3 w-3 animate-pulse rounded-full bg-[var(--accent-secondary)] shadow-[0_0_0_6px_rgba(125,220,211,0.12)]"
+          aria-hidden
+        />
       </div>
 
-      <BrandWordmark className="text-xl sm:text-2xl drop-shadow-[var(--chalk-glow)]" state="idle" />
+      <BrandWordmark
+        className="text-2xl sm:text-[1.6rem] tracking-[0.04em] drop-shadow-[var(--chalk-glow)]"
+        state="idle"
+      />
 
-      <p className="max-w-xl text-sm leading-snug text-text-secondary tracking-[0.01em]">
-        Formuliere deine Frage oder hol dir einen klaren Zweitblick. Matte Schieferoberfläche,
-        dezente Kreide – der Fokus liegt auf Inhalt, nicht auf Deko.
+      <p className="max-w-xl text-sm leading-snug text-text-secondary tracking-[0.02em]">
+        Klare Antworten statt Deko. Matte Schieferoberfläche, dezente Kreide.
       </p>
 
       <div className="flex w-full max-w-md flex-col gap-2 sm:flex-row">
         <button
           onClick={onNewChat}
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border-chalk)] bg-[rgba(236,236,236,0.06)] px-4 py-2.5 text-sm font-semibold text-text-primary transition hover:bg-[rgba(236,236,236,0.09)] hover:shadow-[0_10px_24px_rgba(0,0,0,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-chalk-strong)]"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[color-mix(in_srgb,var(--accent-primary)_65%,transparent)] bg-[var(--accent-primary)] px-4 py-2.5 text-sm font-semibold text-[var(--ink-on-accent)] shadow-[0_14px_32px_rgba(243,214,138,0.4)] transition hover:translate-y-[-1px] hover:shadow-[0_18px_42px_rgba(243,214,138,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--accent-primary)_55%,transparent)]"
         >
-          <Sparkles className="h-4 w-4 text-accent-primary" />
+          <Plus className="h-4 w-4" />
           Neues Gespräch
         </button>
 


### PR DESCRIPTION
## Summary
- deepen the slate palette with a warm chalk accent to create clearer surface hierarchy
- refresh the chat start card with stronger depth, glow accents, and a brighter primary action
- update the unified input bar pills and send control with higher contrast, active markers, and accent cues

## Testing
- npm run verify
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e6e05a148320b4d4c5b4ac11eeaa)