### PR TITLE
feat(chat): add style and creativity context pills to input bar

### DIFF
--- a/src/components/chat/UnifiedInputBar.tsx
+++ b/src/components/chat/UnifiedInputBar.tsx
@@ -5,7 +5,7 @@ import type { ModelEntry } from "@/config/models";
 import { useRoles } from "@/contexts/RolesContext";
 import { useSettings } from "@/hooks/useSettings";
 import { useVisualViewport } from "@/hooks/useVisualViewport";
-import { Cpu, Send, User } from "@/lib/icons";
+import { Cpu, Palette, Send, Sparkles, User } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/Button";
 
@@ -71,6 +71,22 @@ export function UnifiedInputBar({
   const modelLabel = settings.preferredModelId.split("/").pop() || "Modell";
   const roleLabel = activeRole?.name || "Standard";
 
+  // Stil-Label aus Discussion Preset
+  const stylePresetLabels: Record<string, string> = {
+    locker_neugierig: "Locker",
+    edgy_provokant: "Provokant",
+    nuechtern_pragmatisch: "Pragmatisch",
+    akademisch_formell: "Akademisch",
+    freundlich_offen: "Freundlich",
+    analytisch_detailliert: "Analytisch",
+    sarkastisch_witzig: "Sarkastisch",
+    fachlich_tiefgehend: "Fachlich",
+  };
+  const styleLabel = stylePresetLabels[settings.discussionPreset] || "Stil";
+
+  // Kreativitäts-Label
+  const creativityLabel = `${settings.creativity}%`;
+
   return (
     <div className={cn("w-full space-y-3", className)}>
       {/* Context Bar (subdued, doesn't compete with primary action) */}
@@ -94,6 +110,20 @@ export function UnifiedInputBar({
           >
             <User className="h-3.5 w-3.5 opacity-70" />
             <span className="truncate max-w-[140px]">{roleLabel}</span>
+          </button>
+          <button
+            onClick={() => navigate("/settings/behavior")}
+            className="flex items-center gap-1.5 rounded-full border border-white/5 bg-surface-1/60 px-2.5 py-1.5 text-xs font-medium text-ink-secondary transition-colors hover:border-white/10 hover:text-ink-primary hover:bg-surface-2/80"
+          >
+            <Palette className="h-3.5 w-3.5 opacity-70" />
+            <span className="truncate max-w-[90px]">{styleLabel}</span>
+          </button>
+          <button
+            onClick={() => navigate("/settings/behavior")}
+            className="flex items-center gap-1.5 rounded-full border border-white/5 bg-surface-1/60 px-2.5 py-1.5 text-xs font-medium text-ink-secondary transition-colors hover:border-white/10 hover:text-ink-primary hover:bg-surface-2/80"
+          >
+            <Sparkles className="h-3.5 w-3.5 opacity-70" />
+            <span className="truncate max-w-[60px]">{creativityLabel}</span>
           </button>
         </div>
         <span className="text-[10px] text-ink-secondary/60 hidden sm:inline">


### PR DESCRIPTION
Added two new context pills to the chat input bar:
- Style pill (Palette icon): Shows current discussion preset (e.g. "Locker", "Pragmatisch")
- Creativity pill (Sparkles icon): Displays creativity percentage (e.g. "45%")

Both pills navigate to /settings/behavior when clicked, allowing users to quickly access and modify their chat behavior settings.

**Changes:**
- Import Palette and Sparkles icons from @/lib/icons
- Add stylePresetLabels mapping for friendly preset names
- Display 4 context pills: Model, Role, Style, Creativity
- Maintain consistent visual styling with existing pills
- Truncate labels appropriately (max-w-[90px] for style, max-w-[60px] for creativity)

All pills now provide quick context overview and easy navigation to respective settings pages.

# Pull Request

## Description

<!-- Brief description of the changes -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] 🔧 Build/CI changes
- [ ] 🧪 Tests

## Testing

- [ ] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] E2E tests pass locally

## Web Vitals & Performance

- [ ] No degradation in Core Web Vitals (LCP, CLS, INP)
- [ ] Performance impact assessed (if applicable)
- [ ] Bundle size impact assessed (if applicable)

## Accessibility Checklist

- [ ] Keyboard navigation works properly
- [ ] Screen reader compatibility verified
- [ ] Color contrast meets WCAG AA standards
- [ ] Focus management is correct
- [ ] ARIA attributes used appropriately
- [ ] Touch targets meet minimum size requirements (44px)

## Security Checklist

- [ ] No hardcoded secrets or API keys
- [ ] CSP violations checked and resolved
- [ ] Input validation implemented where needed
- [ ] XSS protection verified
- [ ] Dependencies scanned for vulnerabilities

## Browser Compatibility

Tested on:

- [ ] Chrome (latest)
- [ ] Firefox (latest)
- [ ] Safari (latest)
- [ ] Mobile Safari (iOS)
- [ ] Chrome Mobile (Android)

## Mobile UX

- [ ] Responsive design verified
- [ ] Touch interactions work properly
- [ ] Virtual keyboard handling tested
- [ ] Safe area insets respected
- [ ] Loading states work on slow connections

## CSP Compliance

- [ ] No CSP violations introduced
- [ ] All external resources properly allowed
- [ ] Inline scripts/styles avoided or properly handled

## Breaking Changes

<!-- List any breaking changes and migration path -->

## Screenshots/Videos

<!-- Add visual evidence of the changes, especially for UI changes -->

## Related Issues

<!-- Link to related issues -->

Closes #

## Deployment Notes

<!-- Any special deployment considerations -->

## Reviewer Checklist

- [ ] Code follows the project's coding standards
- [ ] Changes are well documented
- [ ] Performance impact is acceptable
- [ ] Security considerations addressed
- [ ] Accessibility requirements met
- [ ] Tests are comprehensive
- [ ] No sensitive data exposed

---

**Note for reviewers**: Please check Web Vitals in DevTools and run accessibility audits before approving.
