### PR TITLE
feat: enhance chat energy orb visuals

### DIFF
--- a/src/components/chat/ChatHeroCore.tsx
+++ b/src/components/chat/ChatHeroCore.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -13,44 +13,115 @@ interface ChatHeroCoreProps {
   lastErrorMessage?: string;
 }
 
-type EnergyVisualConfig = {
-  coreColor: string;
+type OrbLayerConfig = {
+  coreGradient: string;
+  irisGradient: string;
+  rimGradient: string;
   glowColor: string;
   ringColor: string;
   particleColor: string;
-  rotationSpeed: number;
+  segmentColor: string;
+  highlightColor: string;
+  scanlineColor: string;
+  waveColor: string;
+  irisDuration: number;
+  segmentDuration: number;
+  scanlineDuration: number;
+  glareDuration: number;
+  breathRange: [number, number];
+  waveDelay?: number;
 };
 
-const ENERGY_VISUAL_CONFIG: Record<CoreStatus, EnergyVisualConfig> = {
+const ORB_CORE_CONFIG: Record<CoreStatus, OrbLayerConfig> = {
   idle: {
-    coreColor: "from-cyan-500 via-blue-500 to-indigo-500",
-    glowColor: "bg-blue-500/20",
-    ringColor: "border-blue-400/30",
-    particleColor: "bg-blue-400",
-    rotationSpeed: 20,
+    coreGradient: "from-cyan-500 via-indigo-500 to-violet-600",
+    irisGradient: "from-slate-950 via-slate-900 to-slate-800",
+    rimGradient: "from-cyan-200/70 via-indigo-200/60 to-violet-200/60",
+    glowColor: "bg-cyan-500/18",
+    ringColor: "border-cyan-300/35",
+    particleColor: "bg-cyan-200/70",
+    segmentColor: "bg-indigo-200/70",
+    highlightColor: "bg-white/80",
+    scanlineColor: "rgba(255,255,255,0.08)",
+    waveColor: "rgba(59, 207, 255, 0.28)",
+    irisDuration: 36,
+    segmentDuration: 18,
+    scanlineDuration: 12,
+    glareDuration: 10,
+    breathRange: [0.97, 1.02],
   },
   thinking: {
-    coreColor: "from-violet-500 via-purple-500 to-fuchsia-500",
-    glowColor: "bg-violet-500/30",
-    ringColor: "border-violet-400/40",
-    particleColor: "bg-violet-400",
-    rotationSpeed: 5, // Faster (duration is lower)
+    coreGradient: "from-violet-500 via-fuchsia-500 to-indigo-400",
+    irisGradient: "from-slate-950 via-indigo-900 to-slate-800",
+    rimGradient: "from-violet-200/80 via-fuchsia-200/70 to-indigo-200/70",
+    glowColor: "bg-violet-500/24",
+    ringColor: "border-violet-300/45",
+    particleColor: "bg-violet-200/85",
+    segmentColor: "bg-fuchsia-200/85",
+    highlightColor: "bg-white/90",
+    scanlineColor: "rgba(255,255,255,0.12)",
+    waveColor: "rgba(232, 121, 249, 0.26)",
+    irisDuration: 18,
+    segmentDuration: 10,
+    scanlineDuration: 8,
+    glareDuration: 8,
+    breathRange: [0.98, 1.04],
   },
   streaming: {
-    coreColor: "from-emerald-400 via-cyan-400 to-blue-500",
-    glowColor: "bg-cyan-500/40",
-    ringColor: "border-cyan-400/50",
-    particleColor: "bg-cyan-300",
-    rotationSpeed: 3, // Fastest
+    coreGradient: "from-emerald-400 via-cyan-400 to-blue-500",
+    irisGradient: "from-slate-950 via-cyan-900 to-slate-800",
+    rimGradient: "from-emerald-200/80 via-cyan-200/80 to-blue-200/80",
+    glowColor: "bg-cyan-500/30",
+    ringColor: "border-cyan-300/60",
+    particleColor: "bg-cyan-200",
+    segmentColor: "bg-emerald-200/90",
+    highlightColor: "bg-white/95",
+    scanlineColor: "rgba(255,255,255,0.16)",
+    waveColor: "rgba(103, 232, 249, 0.34)",
+    irisDuration: 12,
+    segmentDuration: 6,
+    scanlineDuration: 6,
+    glareDuration: 6,
+    breathRange: [0.99, 1.05],
+    waveDelay: 1.8,
   },
   error: {
-    coreColor: "from-red-600 via-orange-600 to-red-500",
-    glowColor: "bg-red-500/40",
-    ringColor: "border-red-500/40",
-    particleColor: "bg-red-500",
-    rotationSpeed: 50, // Very slow or erratic
+    coreGradient: "from-red-600 via-orange-600 to-amber-500",
+    irisGradient: "from-black via-red-950 to-amber-900",
+    rimGradient: "from-orange-200/80 via-red-200/70 to-amber-200/70",
+    glowColor: "bg-red-500/30",
+    ringColor: "border-orange-300/60",
+    particleColor: "bg-orange-200",
+    segmentColor: "bg-orange-200/90",
+    highlightColor: "bg-white",
+    scanlineColor: "rgba(255,255,255,0.18)",
+    waveColor: "rgba(252, 211, 77, 0.32)",
+    irisDuration: 50,
+    segmentDuration: 20,
+    scanlineDuration: 10,
+    glareDuration: 7,
+    breathRange: [0.98, 1.03],
   },
 };
+
+const innerParticles = Array.from({ length: 14 }, (_, index) => ({
+  angle: (360 / 14) * index + (index % 2 === 0 ? 6 : -4),
+  radius: 37 + (index % 3) * 2,
+  size: index % 3 === 0 ? 3 : 2,
+  opacity: 0.5 + (index % 4) * 0.1,
+}));
+
+const outerParticles = Array.from({ length: 20 }, (_, index) => ({
+  angle: (360 / 20) * index + (index % 2 === 0 ? -8 : 10),
+  radius: 46 + (index % 5) * 1.5,
+  size: index % 4 === 0 ? 3 : 2,
+  opacity: 0.35 + (index % 5) * 0.07,
+}));
+
+const dataSegments = Array.from({ length: 28 }, (_, index) => ({
+  angle: (360 / 28) * index,
+  long: index % 3 === 0,
+}));
 
 export function ChatHeroCore({
   status,
@@ -59,255 +130,354 @@ export function ChatHeroCore({
   creativityLabel,
   lastErrorMessage,
 }: ChatHeroCoreProps) {
-  const config = ENERGY_VISUAL_CONFIG[status];
+  const config = ORB_CORE_CONFIG[status];
   const [glitching, setGlitching] = useState(false);
+  const [tapPulse, setTapPulse] = useState(false);
 
   useEffect(() => {
     if (status === "error") {
       setGlitching(true);
-      const timer = setTimeout(() => setGlitching(false), 600);
+      const timer = setTimeout(() => setGlitching(false), 800);
       return () => clearTimeout(timer);
     }
     setGlitching(false);
     return undefined;
   }, [status]);
 
-  const [tapPulse, setTapPulse] = useState(false);
-
   const handleTap = () => {
     setTapPulse(true);
-    // Haptic feedback if available (navigator.vibrate) - usually 10-20ms is enough for a "click" feel
     if (typeof navigator !== "undefined" && navigator.vibrate) {
       navigator.vibrate(15);
     }
-    setTimeout(() => setTapPulse(false), 300);
+    setTimeout(() => setTapPulse(false), 320);
   };
 
+  const particleFlickerDurations = useMemo(
+    () =>
+      innerParticles.map((_, index) =>
+        status === "streaming"
+          ? 1200 + index * 35
+          : status === "thinking"
+            ? 1400 + index * 45
+            : 1800 + index * 50,
+      ),
+    [status],
+  );
+
   return (
-    <div className="flex flex-col items-center justify-center gap-6 pb-6 pt-2 w-full animate-fade-in">
-      {/* Energy Sphere Container - Now Interactive & Floating */}
+    <div className="flex flex-col items-center justify-center gap-6 pb-8 pt-[calc(env(safe-area-inset-top,0px)+8px)] w-full animate-fade-in">
       <motion.div
-        className={cn("relative w-40 h-40 flex items-center justify-center cursor-pointer")}
+        className={cn(
+          "relative flex items-center justify-center aspect-square",
+          "w-[clamp(5.5rem,16vw,7.75rem)] h-[clamp(5.5rem,16vw,7.75rem)]",
+          "md:w-[clamp(6.25rem,12vw,9rem)] md:h-[clamp(6.25rem,12vw,9rem)]",
+          "max-w-[10rem] min-w-[4.75rem]", // keep mobile friendly
+        )}
         animate={{
-          y: [0, -8, 0], // Gentle levitation
-          scale: status === "idle" && !tapPulse ? [1, 1.02, 1] : 1, // Breathing effect when idle and not tapped
+          y: [0, -10, 0],
+          scale: tapPulse
+            ? 0.98
+            : [config.breathRange[0], config.breathRange[1], config.breathRange[0]],
         }}
         transition={{
-          y: { duration: 4, repeat: Infinity, ease: "easeInOut" },
-          scale: { duration: 3, repeat: Infinity, ease: "easeInOut" }, // Slower for breathing
+          y: { duration: 5, repeat: Infinity, ease: "easeInOut" },
+          scale: { duration: 6, repeat: Infinity, ease: "easeInOut" },
         }}
-        whileTap={{ scale: 0.95 }}
+        whileTap={{ scale: 0.96 }}
         onClick={handleTap}
       >
-        {/* Background Ambient Glow - Pulsing */}
+        {/* Ambient Glow */}
         <div
           className={cn(
-            "absolute inset-0 rounded-full blur-3xl transition-all duration-700 opacity-40 animate-pulse",
+            "absolute inset-[-10%] rounded-full blur-3xl transition-all duration-700 opacity-60",
             config.glowColor,
-            glitching && "animate-pulse",
-            tapPulse && "opacity-80 scale-110 duration-150", // Flash on tap
-            // Synchronize glow with breathing effect
-            status === "idle" && !tapPulse && "animate-pulse-subtle", // Custom pulse for breathing
+            glitching && "animate-orb-shake",
+            tapPulse && "opacity-90",
           )}
         />
-
-        {/* Secondary Static Glow for Depth */}
         <div
           className={cn(
-            "absolute inset-4 rounded-full blur-2xl transition-colors duration-700 opacity-30 mix-blend-screen",
+            "absolute inset-2 rounded-full blur-2xl opacity-40 mix-blend-screen transition-colors duration-700",
             config.glowColor,
           )}
         />
 
-        {/* Shockwave Effect (Expanding Ring) */}
-        {(status === "thinking" || status === "streaming" || tapPulse) && (
+        {/* Outer shell and particle belts */}
+        <div className="absolute inset-0">
+          {/* scope container */}
           <div
             className={cn(
-              "absolute inset-0 rounded-full border opacity-0",
+              "absolute inset-[-4%] rounded-full border border-white/5 bg-gradient-to-br opacity-80",
               config.ringColor,
-              "animate-ping-slow",
-            )}
-            style={{ animationDuration: tapPulse ? "0.6s" : "3s" }}
-          />
-        )}
-
-        {/* Core Energy Ball */}
-        <div className="relative w-16 h-16 flex items-center justify-center z-10">
-          {/* Base Core Gradient */}
-          <div
-            className={cn(
-              "absolute inset-0 rounded-full bg-gradient-to-br blur-md opacity-80 transition-all duration-700",
-              config.coreColor,
-              tapPulse && "brightness-150 scale-105",
             )}
           />
 
-          {/* Internal Plasma/Turbulence (Spinning Conic) */}
-          <div className="absolute inset-0 rounded-full overflow-hidden opacity-60 mix-blend-overlay">
-            <div
-              className={cn(
-                "w-[200%] h-[200%] -translate-x-1/4 -translate-y-1/4 bg-[conic-gradient(from_0deg,transparent_0deg,rgba(255,255,255,0.5)_180deg,transparent_360deg)] animate-spin-slow",
-                tapPulse && "duration-[500ms]", // Spin faster on tap
-              )}
-            />
-          </div>
+          {/* Outer data ring with micro segments */}
+          <motion.div
+            className="absolute inset-[-6%]"
+            animate={{ rotate: 360 }}
+            transition={{ duration: config.segmentDuration, repeat: Infinity, ease: "linear" }}
+          >
+            {dataSegments.map((segment, index) => (
+              <span
+                key={`segment-${segment.angle}`}
+                className={cn(
+                  "absolute left-1/2 top-1/2 origin-left rounded-full",
+                  segment.long ? "h-[3px] w-3" : "h-[2px] w-2",
+                  config.segmentColor,
+                  "shadow-[0_0_8px_rgba(255,255,255,0.08)]",
+                  status === "streaming"
+                    ? "animate-orb-bits-fast"
+                    : status === "thinking"
+                      ? "animate-orb-bits"
+                      : "opacity-80",
+                )}
+                style={{
+                  transform: `rotate(${segment.angle}deg) translateX(48%)`,
+                  animationDelay: `${index * 40}ms`,
+                }}
+              />
+            ))}
+          </motion.div>
 
-          {/* Core Highlight/Rim */}
-          <div
-            className={cn(
-              "absolute inset-1 rounded-full bg-gradient-to-tl mix-blend-screen transition-all duration-700",
-              config.coreColor,
-              "animate-pulse-glow",
-            )}
-          />
+          {/* Outer particle belt */}
+          <motion.div
+            className="absolute inset-[-8%]"
+            animate={{ rotate: status === "streaming" ? 360 : status === "thinking" ? 200 : 120 }}
+            transition={{ duration: config.irisDuration, repeat: Infinity, ease: "linear" }}
+          >
+            {outerParticles.map((particle, index) => (
+              <span
+                key={`outer-${index}`}
+                className={cn(
+                  "absolute left-1/2 top-1/2 origin-center rounded-full",
+                  config.particleColor,
+                  "mix-blend-screen animate-orb-twinkle",
+                )}
+                style={{
+                  width: particle.size,
+                  height: particle.size,
+                  opacity: particle.opacity,
+                  transform: `rotate(${particle.angle}deg) translateX(${particle.radius}%)`,
+                  animationDelay: `${index * 55}ms`,
+                  animationDuration: `${particleFlickerDurations[index % particleFlickerDurations.length]}ms`,
+                }}
+              />
+            ))}
+          </motion.div>
+
+          {/* Inner particle belt */}
+          <motion.div
+            className="absolute inset-[-2%]"
+            animate={{
+              rotate: status === "streaming" ? -300 : status === "thinking" ? -200 : -120,
+            }}
+            transition={{ duration: config.segmentDuration, repeat: Infinity, ease: "linear" }}
+          >
+            {innerParticles.map((particle, index) => (
+              <span
+                key={`inner-${index}`}
+                className={cn(
+                  "absolute left-1/2 top-1/2 origin-center rounded-full",
+                  config.particleColor,
+                  "mix-blend-screen animate-orb-twinkle",
+                )}
+                style={{
+                  width: particle.size,
+                  height: particle.size,
+                  opacity: particle.opacity,
+                  transform: `rotate(${particle.angle}deg) translateX(${particle.radius}%)`,
+                  animationDelay: `${index * 35}ms`,
+                  animationDuration: `${particleFlickerDurations[index % particleFlickerDurations.length]}ms`,
+                }}
+              />
+            ))}
+          </motion.div>
         </div>
 
-        {/* Rotating Rings (Orbits) */}
-        {/* Ring 1 - Outer Horizontal-ish - Complex Segmented */}
-        <motion.div
+        {/* Main Orb body */}
+        <div
           className={cn(
-            "absolute w-36 h-36 rounded-full border border-dashed opacity-40",
-            config.ringColor,
-            tapPulse && "border-solid opacity-80",
+            "relative inset-0 w-full h-full rounded-full overflow-visible bg-gradient-to-br",
+            config.coreGradient,
+            glitching && "animate-orb-shake",
+            tapPulse && "scale-[1.01] duration-150",
           )}
-          style={{ borderTopColor: "transparent", borderBottomColor: "transparent" }}
-          animate={{
-            rotateX: [70, 70],
-            rotateY: [0, 360],
-            rotateZ: [0, 360],
-            scale: [1, 1.05, 1],
-          }}
-          transition={{
-            duration: tapPulse ? 0.5 : config.rotationSpeed * 1.2,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-        />
-
-        {/* Ring 2 - Vertical-ish - Fine Dotted */}
-        <motion.div
-          className={cn(
-            "absolute w-32 h-32 rounded-full border-[1.5px] border-dotted opacity-60",
-            config.ringColor,
-          )}
-          style={{ borderLeftColor: "transparent", borderRightColor: "transparent" }}
-          animate={{
-            rotateX: [0, 360],
-            rotateY: [30, 30],
-            rotateZ: [0, -360],
-          }}
-          transition={{
-            duration: tapPulse ? 0.5 : config.rotationSpeed * 1.5,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-        />
-
-        {/* Ring 3 - Inner Fast Orbit - Solid Arc */}
-        <motion.div
-          className={cn(
-            "absolute w-24 h-24 rounded-full border-[2px] opacity-70",
-            config.ringColor,
-          )}
-          style={{
-            borderTopColor: "transparent",
-            borderLeftColor: "transparent",
-            borderRightColor: "transparent", // Only 1/4 circle
-          }}
-          animate={{
-            rotateX: [45, 225],
-            rotateY: [45, 225],
-            rotateZ: [0, 360],
-          }}
-          transition={{
-            duration: tapPulse ? 0.5 : config.rotationSpeed * 0.8,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-        />
-
-        {/* Ring 4 - Counter Rotation Arc */}
-        <motion.div
-          className={cn(
-            "absolute w-28 h-28 rounded-full border border-solid opacity-30",
-            config.ringColor,
-          )}
-          style={{
-            borderTopColor: "transparent",
-            borderBottomColor: "transparent",
-            borderRightColor: "transparent",
-          }}
-          animate={{
-            rotateX: [20, -20],
-            rotateY: [0, -360],
-            rotateZ: [10, -10],
-          }}
-          transition={{
-            duration: tapPulse ? 1 : config.rotationSpeed,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-        />
-
-        {/* Floating Particles - Layer 1 (Slow) */}
-        <div className="absolute inset-0 pointer-events-none">
+        >
+          {/* Soft rim and chromatic ring */}
+          <div
+            className={cn(
+              "absolute inset-[4%] rounded-full bg-gradient-to-br opacity-50 blur-[1px]",
+              config.rimGradient,
+            )}
+          />
+          <div className="absolute inset-[6%] rounded-full border border-white/10 shadow-glow-md bg-gradient-to-tr from-white/4 via-white/2 to-white/4" />
           <motion.div
-            className="absolute inset-0"
+            className="absolute inset-[10%] rounded-full"
+            style={{
+              backgroundImage:
+                "conic-gradient(from 120deg, rgba(255,255,255,0.12), transparent 30deg, rgba(255,255,255,0.08) 210deg, transparent 260deg, rgba(255,255,255,0.12))",
+            }}
             animate={{ rotate: 360 }}
-            transition={{ duration: 25, repeat: Infinity, ease: "linear" }}
+            transition={{ duration: config.irisDuration * 1.1, repeat: Infinity, ease: "linear" }}
+          />
+
+          {/* Iris */}
+          <motion.div
+            className={cn(
+              "absolute inset-[15%] rounded-full bg-gradient-to-br overflow-hidden shadow-inner",
+              config.irisGradient,
+            )}
+            animate={{ rotate: 360 }}
+            transition={{ duration: config.irisDuration, repeat: Infinity, ease: "linear" }}
           >
+            {/* Iris radial texture */}
             <div
-              className={cn(
-                "absolute top-0 left-1/2 w-1.5 h-1.5 rounded-full blur-[1px]",
-                config.particleColor,
-              )}
+              className="absolute inset-0 opacity-70 mix-blend-overlay"
+              style={{
+                backgroundImage:
+                  "conic-gradient(from 0deg, rgba(255,255,255,0.08), rgba(255,255,255,0.0) 35deg, rgba(255,255,255,0.12) 90deg, transparent 120deg, rgba(255,255,255,0.08) 160deg, rgba(255,255,255,0.0) 210deg, rgba(255,255,255,0.08) 260deg, transparent 310deg)",
+              }}
+            />
+            <motion.div
+              className="absolute inset-[6%] rounded-full opacity-80"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at 50% 50%, rgba(255,255,255,0.25), rgba(255,255,255,0.05) 45%, rgba(0,0,0,0.35) 65%, transparent 70%)",
+              }}
+              animate={{ rotate: -360 }}
+              transition={{ duration: config.irisDuration * 1.5, repeat: Infinity, ease: "linear" }}
             />
             <div
-              className={cn(
-                "absolute bottom-8 right-1/4 w-1 h-1 rounded-full blur-[0.5px] opacity-70",
-                config.particleColor,
-              )}
+              className="absolute inset-[18%] rounded-full opacity-30 mix-blend-screen"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at 20% 20%, rgba(255,255,255,0.35), transparent 35%), radial-gradient(circle at 80% 70%, rgba(255,255,255,0.18), transparent 40%)",
+                backgroundSize: "120% 120%",
+              }}
             />
             <div
+              className="absolute inset-0 opacity-30 mix-blend-screen"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.14) 0.7px, transparent 0.7px)",
+                backgroundSize: "12px 12px",
+              }}
+            />
+
+            {/* Data belt overlay */}
+            <motion.div
+              className="absolute inset-[6%]"
+              animate={{ rotate: -360 }}
+              transition={{
+                duration: config.segmentDuration * 1.6,
+                repeat: Infinity,
+                ease: "linear",
+              }}
+            >
+              {dataSegments.slice(0, 16).map((segment, index) => (
+                <span
+                  key={`inner-segment-${segment.angle}`}
+                  className={cn(
+                    "absolute left-1/2 top-1/2 origin-left h-[2px] w-2 rounded-full",
+                    config.segmentColor,
+                    "opacity-80 animate-orb-bits-subtle",
+                  )}
+                  style={{
+                    transform: `rotate(${segment.angle * 1.5}deg) translateX(32%)`,
+                    animationDelay: `${index * 55}ms`,
+                  }}
+                />
+              ))}
+            </motion.div>
+
+            {/* Scanline overlay */}
+            <div
               className={cn(
-                "absolute top-1/3 left-4 w-1 h-1 rounded-full blur-[0.5px] opacity-60",
-                config.particleColor,
+                "absolute inset-[10%] rounded-full overflow-hidden pointer-events-none",
+                status !== "idle" ? "animate-orb-scanline" : "animate-orb-scanline-slow",
               )}
+              style={{ animationDuration: `${config.scanlineDuration}s` }}
+            >
+              <div
+                className="absolute inset-0"
+                style={{
+                  backgroundImage: `linear-gradient(180deg, transparent 35%, ${config.scanlineColor} 50%, transparent 65%)`,
+                }}
+              />
+            </div>
+
+            {/* Glare overlay */}
+            <div
+              className={cn(
+                "absolute inset-0 rounded-full bg-gradient-to-tr opacity-40 mix-blend-screen",
+                status === "error"
+                  ? "from-white/8 via-white/16 to-white/10"
+                  : "from-white/10 via-white/20 to-white/14",
+                "animate-orb-glare",
+              )}
+              style={{ animationDuration: `${config.glareDuration}s` }}
             />
           </motion.div>
 
-          {/* Floating Particles - Layer 2 (Fast Counter) */}
+          {/* Pupil with depth */}
+          <div className="absolute inset-[40%] rounded-full bg-gradient-to-b from-slate-950 via-black to-slate-950 shadow-[0_0_18px_rgba(0,0,0,0.4)]" />
           <motion.div
-            className="absolute inset-0"
-            animate={{ rotate: -360 }}
-            transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
-          >
-            <div
-              className={cn(
-                "absolute bottom-2 right-1/2 w-1.5 h-1.5 rounded-full blur-[1px]",
-                config.particleColor,
-              )}
-            />
-            <div
-              className={cn(
-                "absolute top-6 left-1/4 w-1 h-1 rounded-full blur-[0.5px] opacity-70",
-                config.particleColor,
-              )}
-            />
-          </motion.div>
+            className="absolute inset-[42%] rounded-full bg-gradient-to-b from-slate-900 via-slate-800 to-slate-950 shadow-inner"
+            animate={{
+              scale: tapPulse
+                ? 0.92
+                : status === "streaming"
+                  ? [0.92, 1.02, 0.92]
+                  : status === "thinking"
+                    ? [0.95, 1.04, 0.95]
+                    : [0.97, 1.02, 0.97],
+            }}
+            transition={{
+              duration: status === "streaming" ? 1.2 : status === "thinking" ? 1.8 : 3,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
+          <div className="absolute inset-[45%] rounded-full bg-gradient-to-br from-black via-slate-900 to-black" />
+          <div className={cn("absolute inset-[52%] rounded-full", config.highlightColor)} />
 
-          {/* Floating Particles - Layer 3 (Vertical Orbit) */}
+          {/* Highlight / lens flare */}
           <motion.div
-            className="absolute inset-0"
-            animate={{ rotateX: 360, rotateY: 45 }}
-            transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
-          >
-            <div
-              className={cn(
-                "absolute top-0 left-1/2 w-1 h-1 rounded-full bg-white blur-[0.5px] opacity-80",
-              )}
+            className="absolute h-5 w-5 rounded-full bg-white/50 blur-[6px]"
+            style={{ top: "22%", left: "30%" }}
+            animate={{
+              x: [0, status === "streaming" ? 3 : 2, 0],
+              y: [0, status === "streaming" ? -3 : -2, 0],
+              opacity: [0.6, 0.9, 0.6],
+              scale: [0.95, 1.05, 0.95],
+            }}
+            transition={{
+              duration: status === "streaming" ? 2.2 : 3.2,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+          />
+
+          {/* Pulsing wave for streaming */}
+          {status === "streaming" && (
+            <motion.div
+              className={cn("absolute inset-[14%] rounded-full border", config.ringColor)}
+              style={{ backgroundColor: config.waveColor }}
+              animate={{ scale: [0.95, 1.5], opacity: [0.5, 0] }}
+              transition={{
+                duration: 2,
+                repeat: Infinity,
+                repeatDelay: config.waveDelay ?? 2,
+                ease: "easeOut",
+              }}
             />
-          </motion.div>
+          )}
+
+          {/* Glitch sheen for error */}
+          {status === "error" && glitching && (
+            <div className="absolute inset-[8%] rounded-full border border-orange-300/50 mix-blend-screen animate-orb-shake" />
+          )}
         </div>
       </motion.div>
 
@@ -333,11 +503,10 @@ export function ChatHeroCore({
             : "Tippe unten eine Frage ein oder wähle einen der Vorschläge."}
         </motion.p>
 
-        {/* Status Line */}
         <motion.div
           className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-[10px] uppercase tracking-wider text-ink-tertiary mt-2 pt-2 border-t border-white/5"
           initial={{ opacity: 0 }}
-          animate={{ opacity: 0.7 }}
+          animate={{ opacity: 0.8 }}
           transition={{ delay: 0.3 }}
         >
           <span

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -383,6 +383,13 @@ export default {
         "orb-pupil-streaming": "orbPupilPulse 0.5s ease-in-out infinite",
         "orb-wave": "orbWave 2s ease-out infinite",
         "orb-shake": "orbShake 0.4s ease-in-out",
+        "orb-bits": "orbBits 3s linear infinite",
+        "orb-bits-fast": "orbBits 1.6s linear infinite",
+        "orb-bits-subtle": "orbBits 4.2s linear infinite",
+        "orb-twinkle": "orbTwinkle 2.6s ease-in-out infinite",
+        "orb-scanline": "orbScanline 8s linear infinite",
+        "orb-scanline-slow": "orbScanline 14s linear infinite",
+        "orb-glare": "orbGlare 10s ease-in-out infinite",
         "pulse-subtle": "pulse-subtle 3s ease-in-out infinite", // Slower pulse for breathing effect
         "ping-slow": "pingSlow 3s cubic-bezier(0, 0, 0.2, 1) infinite",
       },
@@ -552,6 +559,26 @@ export default {
           "70%": { transform: "translate(-3px, 1px)" },
           "80%": { transform: "translate(2px, -1px)" },
           "90%": { transform: "translate(-1px, 2px)" },
+        },
+        orbBits: {
+          "0%": { opacity: "0.6", transform: "scale(1)" },
+          "30%": { opacity: "0.9" },
+          "60%": { opacity: "0.55", transform: "scale(1.05)" },
+          "100%": { opacity: "0.6", transform: "scale(1)" },
+        },
+        orbTwinkle: {
+          "0%": { opacity: "0.4", transform: "scale(0.9)" },
+          "50%": { opacity: "1", transform: "scale(1.25)" },
+          "100%": { opacity: "0.45", transform: "scale(0.9)" },
+        },
+        orbScanline: {
+          "0%": { transform: "translateY(120%)" },
+          "100%": { transform: "translateY(-120%)" },
+        },
+        orbGlare: {
+          "0%": { transform: "translate3d(-6%, -4%, 0) rotate(-6deg)", opacity: "0.32" },
+          "50%": { transform: "translate3d(4%, 6%, 0) rotate(4deg)", opacity: "0.58" },
+          "100%": { transform: "translate3d(-6%, -4%, 0) rotate(-6deg)", opacity: "0.32" },
         },
         "pulse-subtle": {
           "0%, 100%": { opacity: "0.4" },


### PR DESCRIPTION
## Summary
- redesign the chat energy orb core with layered iris textures, particle belts, data segments, and depth/pupil highlights while keeping status logic intact
- add responsive sizing and new orbital animations (scanline, glare, twinkle, bit sweeps) to enrich the visual language without hurting performance
- refine glow/padding and streaming pulses for mobile-safe presentation across statuses

## Testing
- npm run verify


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693988beca4c8320a3beb43c618b7bd0)