### PR TITLE
Add animated streak overlay to ChatHeroCore orb

### DIFF
--- a/tests/polyfills.ts
+++ b/tests/polyfills.ts
@@ -42,3 +42,28 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: vi.fn(),
   })),
 });
+
+class ResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(): void {
+    // no-op for tests
+  }
+
+  unobserve(): void {
+    // no-op for tests
+  }
+
+  disconnect(): void {
+    // no-op for tests
+  }
+}
+
+Object.defineProperty(global, "ResizeObserver", {
+  writable: true,
+  value: ResizeObserver,
+});


### PR DESCRIPTION
## Summary
- add an animated streak layer above the ChatHeroCore iris using the purple palette and screen blending
- tune streak rotation/flow speeds with Framer Motion based on orb status to keep the effect lightweight
- polyfill ResizeObserver in tests to keep smoke tests stable

## Testing
- npm run verify
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bbdb1f0c832096a572a9926fec61)